### PR TITLE
Enable primary keys on trace and result repository

### DIFF
--- a/core/java/iesi-core/pom.xml
+++ b/core/java/iesi-core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.metadew</groupId>
     <artifactId>iesi-core</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <name>io.metadew:iesi-core</name>
     <description>IESI Core artifact</description>
     <url>https://metadew.github.io/metadew/</url>

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/database/SchemaDatabase.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/database/SchemaDatabase.java
@@ -65,6 +65,7 @@ public abstract class SchemaDatabase extends Database {
             counter++;
         }
 
+        getPrimaryKeyConstraints(table).ifPresent(primaryKeysConstraint -> createQuery.append(",\n").append(primaryKeysConstraint));
         createQuery.append("\n)").append(createQueryExtras()).append(";");
         //createQuery.append(fieldComments).append("\n\n");
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/operation/DbOracleConnectionService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/operation/DbOracleConnectionService.java
@@ -1,12 +1,7 @@
 package io.metadew.iesi.connection.operation;
 
 import io.metadew.iesi.connection.database.OracleDatabase;
-import io.metadew.iesi.connection.database.TeradataDatabase;
-import io.metadew.iesi.connection.database.connection.TeradataDatabaseConnection;
-import io.metadew.iesi.framework.crypto.FrameworkCrypto;
-import io.metadew.iesi.framework.execution.FrameworkControl;
 import io.metadew.iesi.metadata.definition.connection.Connection;
-import io.metadew.iesi.metadata.definition.connection.ConnectionParameter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/tools/SQLTools.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/tools/SQLTools.java
@@ -46,6 +46,10 @@ public final class SQLTools {
         return _long == null ? "null" : _long.toString();
     }
 
+    public static String GetStringForSQL(Double _double) {
+        return _double == null ? "null" : _double.toString();
+    }
+
     public static String GetStringForSQL(Timestamp input) {
         if (input == null) {
             return "null";

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/framework/crypto/algo/AESEncryptBasic.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/framework/crypto/algo/AESEncryptBasic.java
@@ -1,6 +1,9 @@
 package io.metadew.iesi.framework.crypto.algo;
 
-import javax.crypto.*;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/framework/instance/FrameworkInstance.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/framework/instance/FrameworkInstance.java
@@ -12,8 +12,6 @@ import io.metadew.iesi.metadata.execution.MetadataControl;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
 import io.metadew.iesi.metadata.repository.configuration.MetadataRepositoryConfiguration;
 import io.metadew.iesi.runtime.ExecutorService;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/launch/ServerLauncher.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/launch/ServerLauncher.java
@@ -3,7 +3,6 @@ package io.metadew.iesi.launch;
 import io.metadew.iesi.framework.definition.FrameworkInitializationFile;
 import io.metadew.iesi.framework.execution.FrameworkExecutionContext;
 import io.metadew.iesi.framework.instance.FrameworkInstance;
-import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.Context;
 import io.metadew.iesi.runtime.ExecutionRequestListener;
 import org.apache.commons.cli.*;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/design/ActionDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/design/ActionDesignTraceConfiguration.java
@@ -2,8 +2,6 @@ package io.metadew.iesi.metadata.configuration.action.design;
 
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
-import io.metadew.iesi.metadata.configuration.action.design.exception.ActionDesignTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.action.design.exception.ActionDesignTraceDoesNotExistException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.action.design.ActionDesignTrace;
@@ -102,10 +100,6 @@ public class ActionDesignTraceConfiguration extends Configuration<ActionDesignTr
     @Override
     public void delete(ActionDesignTraceKey actionDesignTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionDesignTrace {0}.", actionDesignTraceKey.toString()));
-        if (!exists(actionDesignTraceKey)) {
-            throw new ActionDesignTraceDoesNotExistException(MessageFormat.format(
-                    "ActionTrace {0} does not exists", actionDesignTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(actionDesignTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -121,10 +115,6 @@ public class ActionDesignTraceConfiguration extends Configuration<ActionDesignTr
     @Override
     public void insert(ActionDesignTrace actionDesignTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ActionDesignTrace {0}.", actionDesignTrace.toString()));
-        if (exists(actionDesignTrace.getMetadataKey())) {
-            throw new ActionDesignTraceAlreadyExistsException(MessageFormat.format(
-                    "ActionParameterTrace {0} already exists", actionDesignTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(actionDesignTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -147,4 +137,29 @@ public class ActionDesignTraceConfiguration extends Configuration<ActionDesignTr
                 SQLTools.GetStringForSQL(actionDesignTrace.getErrorExpected()) + "," +
                 SQLTools.GetStringForSQL(actionDesignTrace.getErrorStop()) + ");";
     }
+
+    @Override
+    public void update(ActionDesignTrace actionDesignTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ActionDesignTrace {0}.", actionDesignTrace.getMetadataKey().toString()));
+        String updateStatement = updateStatement(actionDesignTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ActionDesignTrace actionDesignTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionDesignTraces") +
+                " SET ACTION_NB = " + SQLTools.GetStringForSQL(actionDesignTrace.getNumber()) + "," +
+                "ACTION_TYP_NM = " + SQLTools.GetStringForSQL(actionDesignTrace.getType()) + "," +
+                "ACTION_NM = " + SQLTools.GetStringForSQL(actionDesignTrace.getName()) + "," +
+                "ACTION_DSC = " + SQLTools.GetStringForSQL(actionDesignTrace.getDescription()) + "," +
+                "COMP_NM = " + SQLTools.GetStringForSQL(actionDesignTrace.getComponent()) + "," +
+                "ITERATION_VAL = " + SQLTools.GetStringForSQL(actionDesignTrace.getIteration()) + "," +
+                "CONDITION_VAL = " + SQLTools.GetStringForSQL(actionDesignTrace.getCondition()) + "," +
+                "RETRIES_VAL = " + SQLTools.GetStringForSQL(actionDesignTrace.getRetries()) + "," +
+                "EXP_ERR_FL = " + SQLTools.GetStringForSQL(actionDesignTrace.getErrorExpected()) + "," +
+                "STOP_ERR_FL =" + SQLTools.GetStringForSQL(actionDesignTrace.getErrorStop()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionDesignTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionDesignTrace.getMetadataKey().getProcessId()) +
+                " AND ACTION_ID = " + SQLTools.GetStringForSQL(actionDesignTrace.getMetadataKey().getActionId()) + ";";
+    }
+
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/performance/ActionPerformanceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/performance/ActionPerformanceConfiguration.java
@@ -44,7 +44,6 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
                     + getMetadataRepository().getTableNameByLabel("ActionResultPerformances") + " where " +
                     "RUN_ID = " + SQLTools.GetStringForSQL(key.getRunId()) + " AND " +
                     "PRC_ID = " + key.getProcedureId() + " AND " +
-                    "ACTION_ID = " + SQLTools.GetStringForSQL(key.getActionId()) + " AND " +
                     "SCOPE_NM = " + SQLTools.GetStringForSQL(key.getScope()) + ";";
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(queryAction, "reader");
             if (cachedRowSet.size() == 0) {
@@ -55,9 +54,9 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
             cachedRowSet.next();
             return Optional.of(new ActionPerformance(new ActionPerformanceKey(cachedRowSet.getString("RUN_ID"),
                     cachedRowSet.getLong("PRC_ID"),
-                    cachedRowSet.getString("ACTION_ID"),
                     cachedRowSet.getString("SCOPE_NM")),
                     cachedRowSet.getString("CONTEXT_NM"),
+                    cachedRowSet.getString("ACTION_ID"),
                     cachedRowSet.getTimestamp("STRT_TMS").toLocalDateTime(),
                     cachedRowSet.getTimestamp("END_TMS").toLocalDateTime(),
                     cachedRowSet.getDouble("DURATION_VAL")));
@@ -76,9 +75,9 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
             while (cachedRowSet.next()) {
                 actionPerformances.add(new ActionPerformance(new ActionPerformanceKey(cachedRowSet.getString("RUN_ID"),
                         cachedRowSet.getLong("PRC_ID"),
-                        cachedRowSet.getString("ACTION_ID"),
                         cachedRowSet.getString("SCOPE_NM")),
                         cachedRowSet.getString("CONTEXT_NM"),
+                        cachedRowSet.getString("ACTION_ID"),
                         cachedRowSet.getTimestamp("STRT_TMS").toLocalDateTime(),
                         cachedRowSet.getTimestamp("END_TMS").toLocalDateTime(),
                         cachedRowSet.getDouble("DURATION_VAL")));
@@ -94,8 +93,7 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
         String queryAction = "delete from "
                 + getMetadataRepository().getTableNameByLabel("ActionResultPerformances") + " where " +
                 "RUN_ID = " + SQLTools.GetStringForSQL(key.getRunId()) + " AND " +
-                "PRC_ID = " + key.getProcedureId() + " AND " +
-                "ACTION_ID = " + SQLTools.GetStringForSQL(key.getActionId()) + " AND " +
+                "PRC_ID = " + SQLTools.GetStringForSQL(key.getProcedureId()) + " AND " +
                 "SCOPE_NM = " + SQLTools.GetStringForSQL(key.getScope()) + ";";
         getMetadataRepository().executeUpdate(queryAction);
     }
@@ -107,7 +105,7 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
                 " (RUN_ID, PRC_ID, ACTION_ID, SCOPE_NM, CONTEXT_NM, STRT_TMS, END_TMS, DURATION_VAL) values (" +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getRunId()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getProcedureId()) + ", " +
-                SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getActionId()) + ", " +
+                SQLTools.GetStringForSQL(actionPerformance.getActionId()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getScope()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getContext()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getStartTimestamp()) + ", " +
@@ -126,7 +124,7 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
                 "DURATION_VAL = " + SQLTools.GetStringForSQL(actionPerformance.getDuration()) +
                 " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getRunId()) +
                 " AND PRC_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getProcedureId()) +
-                " ACTION_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getActionId()) +
+                " ACTION_ID = " + SQLTools.GetStringForSQL(actionPerformance.getActionId()) +
                 " AND SCOPE_NM =" + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getScope()) + ";";
 
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/performance/ActionPerformanceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/performance/ActionPerformanceConfiguration.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 public class ActionPerformanceConfiguration extends Configuration<ActionPerformance, ActionPerformanceKey> {
 
-
     private static final Logger LOGGER = LogManager.getLogger();
     private static ActionPerformanceConfiguration INSTANCE;
 
@@ -92,10 +91,6 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
 
     @Override
     public void delete(ActionPerformanceKey key) throws ActionPerformanceDoesNotExistException {
-        if (!exists(key)) {
-            throw new ActionPerformanceDoesNotExistException(MessageFormat.format("Action Performance {0}-{1}-{2}-{3} does not exist",
-                    key.getRunId(), key.getProcedureId(), key.getActionId(), key.getScope()));
-        }
         String queryAction = "delete from "
                 + getMetadataRepository().getTableNameByLabel("ActionResultPerformances") + " where " +
                 "RUN_ID = " + SQLTools.GetStringForSQL(key.getRunId()) + " AND " +
@@ -107,22 +102,34 @@ public class ActionPerformanceConfiguration extends Configuration<ActionPerforma
 
     @Override
     public void insert(ActionPerformance actionPerformance) throws ActionPerformanceAlreadyExistsException {
-        if (exists(actionPerformance.getMetadataKey())) {
-            throw new ActionPerformanceAlreadyExistsException(MessageFormat.format("Action Performance {0}-{1}-{2}-{3} already exists",
-                    actionPerformance.getMetadataKey().getRunId(), actionPerformance.getMetadataKey().getProcedureId(),
-                    actionPerformance.getMetadataKey().getActionId(), actionPerformance.getMetadataKey().getScope()));
-        }
         String queryAction = "insert into "
                 + getMetadataRepository().getTableNameByLabel("ActionResultPerformances") +
                 " (RUN_ID, PRC_ID, ACTION_ID, SCOPE_NM, CONTEXT_NM, STRT_TMS, END_TMS, DURATION_VAL) values (" +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getRunId()) + ", " +
-                actionPerformance.getMetadataKey().getProcedureId() + ", " +
+                SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getProcedureId()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getActionId()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getScope()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getContext()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getStartTimestamp()) + ", " +
                 SQLTools.GetStringForSQL(actionPerformance.getEndTimestamp()) + ", " +
-                actionPerformance.getDuration() + ");";
+                SQLTools.GetStringForSQL(actionPerformance.getDuration()) + ");";
+        getMetadataRepository().executeUpdate(queryAction);
+    }
+
+    @Override
+    public void update(ActionPerformance actionPerformance) {
+        String queryAction = "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionResultPerformances") +
+                " SET " +
+                "CONTEXT_NM = " + SQLTools.GetStringForSQL(actionPerformance.getContext()) + ", " +
+                "STRT_TMS = " + SQLTools.GetStringForSQL(actionPerformance.getStartTimestamp()) + ", " +
+                "END_TMS = " + SQLTools.GetStringForSQL(actionPerformance.getEndTimestamp()) + ", " +
+                "DURATION_VAL = " + SQLTools.GetStringForSQL(actionPerformance.getDuration()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getProcedureId()) +
+                " ACTION_ID = " + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getActionId()) +
+                " AND SCOPE_NM =" + SQLTools.GetStringForSQL(actionPerformance.getMetadataKey().getScope()) + ";";
+
+
         getMetadataRepository().executeUpdate(queryAction);
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultConfiguration.java
@@ -2,8 +2,6 @@ package io.metadew.iesi.metadata.configuration.action.result;
 
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
-import io.metadew.iesi.metadata.configuration.action.result.exception.ActionResultAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.action.result.exception.ActionResultDoesNotExistException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.action.result.ActionResult;
@@ -92,10 +90,6 @@ public class ActionResultConfiguration extends Configuration<ActionResult, Actio
     @Override
     public void delete(ActionResultKey actionResultKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionResult {0}.", actionResultKey.toString()));
-        if (!exists(actionResultKey)) {
-            throw new ActionResultDoesNotExistException(MessageFormat.format(
-                    "ActionResult {0} does not exists", actionResultKey.toString()));
-        }
         String deleteStatement = deleteStatement(actionResultKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -111,10 +105,6 @@ public class ActionResultConfiguration extends Configuration<ActionResult, Actio
     @Override
     public void insert(ActionResult actionResult) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ActionResult {0}.", actionResult.toString()));
-        if (exists(actionResult.getMetadataKey())) {
-            throw new ActionResultAlreadyExistsException(MessageFormat.format(
-                    "ActionResult {0} already exists", actionResult.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(actionResult);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -134,74 +124,25 @@ public class ActionResultConfiguration extends Configuration<ActionResult, Actio
                 + SQLTools.GetStringForSQL(actionResult.getEndTimestamp()) + ");";
     }
 
-//    public List<ActionResult> getActions(String runId) {
-//        List<ActionResult> actionResults = new ArrayList<>();
-//        String query = "select RUN_ID, PRC_ID, SCRIPT_PRC_ID, ACTION_ID, ACTION_NM, ENV_NM, ST_NM, STRT_TMS, END_TMS from "
-//                + getMetadataRepository()
-//                .getTableNameByLabel("ActionResults")
-//                + " where RUN_ID = '" + runId + "' order by PRC_ID asc, STRT_TMS asc";
-//        CachedRowSet crsActionResults = getMetadataRepository()
-//                .executeQuery(query, "reader");
-//        try {
-//            while (crsActionResults.next()) {
-//                ActionResult actionResult = new ActionResult();
-//                Long processId = crsActionResults.getLong("PRC_ID");
-//                actionResult.setProcessId(processId);
-//                actionResult.setScriptProcessId(crsActionResults.getLong("SCRIPT_PRC_ID"));
-//                actionResult.setActionId(crsActionResults.getString("ACTION_ID"));
-//                actionResult.setActionName(crsActionResults.getString("ACTION_NM"));
-//                actionResult.setEnvironment(crsActionResults.getString("ENV_NM"));
-//                actionResult.setStatus(crsActionResults.getString("ST_NM"));
-//                actionResult.setStartTimestamp(crsActionResults.getString("STRT_TMS"));
-//                actionResult.setEndTimestamp(crsActionResults.getString("END_TMS"));
-//                actionResult.setOutputs(actionResultOutputConfiguration.getActionResultOutputs(runId, processId));
-//                actionResults.add(actionResult);
-//            }
-//            crsActionResults.close();
-//        } catch (Exception e) {
-//            StringWriter StackTrace = new StringWriter();
-//            e.printStackTrace(new PrintWriter(StackTrace));
-//        }
-//
-//        if (actionResults.size() == 0) {
-//            throw new RuntimeException("actionresult.error.empty");
-//        }
-//
-//        return actionResults;
-//    }
-//
-//    public List<ActionResult> getActions(String runId, Long scriptProcessId) {
-//        List<ActionResult> actionResults = new ArrayList<>();
-//        String query = "select RUN_ID, PRC_ID, SCRIPT_PRC_ID, ACTION_ID, ACTION_NM, ENV_NM, ST_NM, STRT_TMS, END_TMS from "
-//                + getMetadataRepository()
-//                .getTableNameByLabel("ActionResults")
-//                + " where RUN_ID = '" + runId + "' and SCRIPT_PRC_ID = " + scriptProcessId + " order by PRC_ID asc, STRT_TMS asc";
-//        CachedRowSet crsActionResults = getMetadataRepository()
-//                .executeQuery(query, "reader");
-//        try {
-//            while (crsActionResults.next()) {
-//                ActionResult actionResult = new ActionResult();
-//                actionResult.setProcessId(crsActionResults.getLong("PRC_ID"));
-//                actionResult.setScriptProcessId(crsActionResults.getLong("SCRIPT_PRC_ID"));
-//                actionResult.setActionId(crsActionResults.getString("ACTION_ID"));
-//                actionResult.setActionName(crsActionResults.getString("ACTION_NM"));
-//                actionResult.setEnvironment(crsActionResults.getString("ENV_NM"));
-//                actionResult.setStatus(crsActionResults.getString("ST_NM"));
-//                actionResult.setStartTimestamp(crsActionResults.getString("STRT_TMS"));
-//                actionResult.setEndTimestamp(crsActionResults.getString("END_TMS"));
-//                actionResults.add(actionResult);
-//            }
-//            crsActionResults.close();
-//        } catch (Exception e) {
-//            StringWriter StackTrace = new StringWriter();
-//            e.printStackTrace(new PrintWriter(StackTrace));
-//        }
-//
-//        if (actionResults.size() == 0) {
-//            throw new RuntimeException("actionresult.error.empty");
-//        }
-//
-//        return actionResults;
-//    }
+    @Override
+    public void update(ActionResult actionResult) {
+        LOGGER.trace(MessageFormat.format("Updating ActionResult {0}.", actionResult.toString()));
+        String updateStatement = updateStatement(actionResult);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
 
+    private String updateStatement(ActionResult actionResult) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionResults") +
+                " SET SCRIPT_PRC_ID = " + SQLTools.GetStringForSQL(actionResult.getScriptProcessId()) + "," +
+                "ACTION_ID = " + SQLTools.GetStringForSQL(actionResult.getMetadataKey().getActionId()) + "," +
+                "ACTION_NM = " + SQLTools.GetStringForSQL(actionResult.getActionName()) + "," +
+                "ENV_NM = " + SQLTools.GetStringForSQL(actionResult.getEnvironment()) + "," +
+                "ST_NM = " + SQLTools.GetStringForSQL(actionResult.getStatus()) + "," +
+                "STRT_TMS = " + SQLTools.GetStringForSQL(actionResult.getStartTimestamp()) + "," +
+                "END_TMS = " + SQLTools.GetStringForSQL(actionResult.getEndTimestamp()) +
+                "WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionResult.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionResult.getMetadataKey().getProcessId()) + ";";
+
+
+    }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultOutputConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultOutputConfiguration.java
@@ -2,8 +2,6 @@ package io.metadew.iesi.metadata.configuration.action.result;
 
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
-import io.metadew.iesi.metadata.configuration.action.result.exception.ActionResultOutputAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.action.result.exception.ActionResultOutputDoesNotExistException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.action.result.ActionResultOutput;
@@ -84,10 +82,6 @@ public class ActionResultOutputConfiguration extends Configuration<ActionResultO
     @Override
     public void delete(ActionResultOutputKey actionResultOutputKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionResultOutput {0}.", actionResultOutputKey.toString()));
-        if (!exists(actionResultOutputKey)) {
-            throw new ActionResultOutputDoesNotExistException(MessageFormat.format(
-                    "ActionResultOutput {0} does not exists", actionResultOutputKey.toString()));
-        }
         String deleteStatement = deleteStatement(actionResultOutputKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -104,10 +98,6 @@ public class ActionResultOutputConfiguration extends Configuration<ActionResultO
     @Override
     public void insert(ActionResultOutput actionResultOutput) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ActionResultOutput {0}.", actionResultOutput.getMetadataKey().toString()));
-        if (exists(actionResultOutput.getMetadataKey())) {
-            throw new ActionResultOutputAlreadyExistsException(MessageFormat.format(
-                    "ActionResult {0} already exists", actionResultOutput.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(actionResultOutput);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -121,6 +111,22 @@ public class ActionResultOutputConfiguration extends Configuration<ActionResultO
                 + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getActionId()) + ","
                 + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getOutputName()) + ","
                 + SQLTools.GetStringForSQL(actionResultOutput.getValue()) + ");";
+    }
+
+    @Override
+    public void update(ActionResultOutput actionResultOutput) {
+        LOGGER.trace(MessageFormat.format("Updating ActionResultOutput {0}.", actionResultOutput.getMetadataKey().toString()));
+        String updateStatement = updateStatement(actionResultOutput);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ActionResultOutput actionResultOutput) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionResultOutputs") +
+                " SET ACTION_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getActionId()) + ", " +
+                "OUT_VAL = " + SQLTools.GetStringForSQL(actionResultOutput.getValue()) +
+                "WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getProcessId()) +
+                " AND OUT_NM = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getOutputName()) + ";";
     }
 
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultOutputConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/result/ActionResultOutputConfiguration.java
@@ -124,7 +124,7 @@ public class ActionResultOutputConfiguration extends Configuration<ActionResultO
         return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionResultOutputs") +
                 " SET ACTION_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getActionId()) + ", " +
                 "OUT_VAL = " + SQLTools.GetStringForSQL(actionResultOutput.getValue()) +
-                "WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getRunId()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getRunId()) +
                 " AND PRC_ID = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getProcessId()) +
                 " AND OUT_NM = " + SQLTools.GetStringForSQL(actionResultOutput.getMetadataKey().getOutputName()) + ";";
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/trace/ActionParameterTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/trace/ActionParameterTraceConfiguration.java
@@ -2,8 +2,6 @@ package io.metadew.iesi.metadata.configuration.action.trace;
 
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
-import io.metadew.iesi.metadata.configuration.action.trace.exception.ActionParameterTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.action.trace.exception.ActionParameterTraceDoesNotExistException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.action.trace.ActionParameterTrace;
@@ -86,10 +84,6 @@ public class ActionParameterTraceConfiguration extends Configuration<ActionParam
     @Override
     public void delete(ActionParameterTraceKey actionParameterTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionParameterTrace {0}.", actionParameterTraceKey.toString()));
-        if (!exists(actionParameterTraceKey)) {
-            throw new ActionParameterTraceDoesNotExistException(MessageFormat.format(
-                    "ActionParameterTrace {0} does not exists", actionParameterTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(actionParameterTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
 
@@ -107,10 +101,6 @@ public class ActionParameterTraceConfiguration extends Configuration<ActionParam
     @Override
     public void insert(ActionParameterTrace actionParameterTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ActionParameterTrace {0}.", actionParameterTrace.getMetadataKey().toString()));
-        if (exists(actionParameterTrace.getMetadataKey())) {
-            throw new ActionParameterTraceAlreadyExistsException(MessageFormat.format(
-                    "ActionParameterTrace {0} already exists", actionParameterTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(actionParameterTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -119,11 +109,7 @@ public class ActionParameterTraceConfiguration extends Configuration<ActionParam
         LOGGER.trace(MessageFormat.format("Inserting ActionParameterTraces {0}.", actionParameterTraces.stream().map(ActionParameterTrace::getMetadataKey).collect(Collectors.toList()).toString()));
         List<String> insertQueries = new ArrayList<>();
         for (ActionParameterTrace actionParameterTrace : actionParameterTraces) {
-            if (exists(actionParameterTrace.getMetadataKey())) {
-                LOGGER.info(MessageFormat.format("ActionParameterTrace {0} already exists. Skipping", actionParameterTrace.getMetadataKey().toString()));
-            } else {
-                insertQueries.add(insertStatement(actionParameterTrace));
-            }
+            insertQueries.add(insertStatement(actionParameterTrace));
         }
         getMetadataRepository().executeBatch(insertQueries);
     }
@@ -136,5 +122,21 @@ public class ActionParameterTraceConfiguration extends Configuration<ActionParam
                 SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getActionId()) + "," +
                 SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getName()) + "," +
                 SQLTools.GetStringForSQL(actionParameterTrace.getValue()) + ");";
+    }
+
+    @Override
+    public void update(ActionParameterTrace actionParameterTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ActionParameterTrace {0}.", actionParameterTrace.getMetadataKey().toString()));
+        String updateStatement = updateStatement(actionParameterTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ActionParameterTrace actionParameterTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionParameterTraces") +
+                " SET ACTION_PAR_VAL = " + SQLTools.GetStringForSQL(actionParameterTrace.getValue()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getProcessId()) +
+                " AND ACTION_ID = " + SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getActionId()) +
+                " AND ACTION_PAR_NM = " + SQLTools.GetStringForSQL(actionParameterTrace.getMetadataKey().getName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/trace/ActionTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/action/trace/ActionTraceConfiguration.java
@@ -2,8 +2,6 @@ package io.metadew.iesi.metadata.configuration.action.trace;
 
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
-import io.metadew.iesi.metadata.configuration.action.trace.exception.ActionTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.action.trace.exception.ActionTraceDoesNotExistException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.action.trace.ActionTrace;
@@ -18,7 +16,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ActionTraceConfiguration extends Configuration<ActionTrace, ActionTraceKey> {
 
@@ -103,10 +100,6 @@ public class ActionTraceConfiguration extends Configuration<ActionTrace, ActionT
     @Override
     public void delete(ActionTraceKey actionTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionTrace {0}.", actionTraceKey.toString()));
-        if (!exists(actionTraceKey)) {
-            throw new ActionTraceDoesNotExistException(MessageFormat.format(
-                    "ActionTrace {0} does not exists", actionTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(actionTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -122,10 +115,6 @@ public class ActionTraceConfiguration extends Configuration<ActionTrace, ActionT
     @Override
     public void insert(ActionTrace actionTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ActionTrace {0}.", actionTrace.getMetadataKey().toString()));
-        if (exists(actionTrace.getMetadataKey())) {
-            throw new ActionTraceAlreadyExistsException(MessageFormat.format(
-                    "ActionParameterTrace {0} already exists", actionTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(actionTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -149,17 +138,37 @@ public class ActionTraceConfiguration extends Configuration<ActionTrace, ActionT
                 SQLTools.GetStringForSQL(actionTrace.getErrorStop()) + ");";
     }
 
-
-    public void insert(List<ActionTrace> actionTraces) throws MetadataAlreadyExistsException, SQLException {
-        LOGGER.trace(MessageFormat.format("Inserting ActionParameterTraces {0}.", actionTraces.stream().map(ActionTrace::getMetadataKey).collect(Collectors.toList()).toString()));
-        List<String> insertQueries = new ArrayList<>();
-        for (ActionTrace actionTrace : actionTraces) {
-            if (exists(actionTrace.getMetadataKey())) {
-                LOGGER.info(MessageFormat.format("ActionParameterTrace {0} already exists. Skipping", actionTrace.getMetadataKey().toString()));
-            } else {
-                insertQueries.add(insertStatement(actionTrace));
-            }
-        }
-        getMetadataRepository().executeBatch(insertQueries);
+    @Override
+    public void update(ActionTrace actionTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ActionTrace {0}.", actionTrace.getMetadataKey().toString()));
+        String updateStatement = updateStatement(actionTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
     }
+
+    private String updateStatement(ActionTrace actionTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ActionTraces") +
+                " SET ACTION_NB = " + SQLTools.GetStringForSQL(actionTrace.getNumber()) + "," +
+                "ACTION_TYP_NM = " + SQLTools.GetStringForSQL(actionTrace.getType()) + "," +
+                "ACTION_NM = " + SQLTools.GetStringForSQL(actionTrace.getName()) + "," +
+                "ACTION_DSC = " + SQLTools.GetStringForSQL(actionTrace.getDescription()) + "," +
+                "COMP_NM = " + SQLTools.GetStringForSQL(actionTrace.getComponent()) + "," +
+                "ITERATION_VAL = " + SQLTools.GetStringForSQL(actionTrace.getIteration()) + "," +
+                "CONDITION_VAL = " + SQLTools.GetStringForSQL(actionTrace.getCondition()) + "," +
+                "RETRIES_VAL = " + SQLTools.GetStringForSQL(actionTrace.getRetries()) + "," +
+                "EXP_ERR_FL = " + SQLTools.GetStringForSQL(actionTrace.getErrorExpected()) + "," +
+                "STOP_ERR_FL =" + SQLTools.GetStringForSQL(actionTrace.getErrorStop()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(actionTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(actionTrace.getMetadataKey().getProcessId()) +
+                " AND ACTION_ID= " + SQLTools.GetStringForSQL(actionTrace.getMetadataKey().getActionId()) + ";";
+    }
+
+
+//    public void insert(List<ActionTrace> actionTraces) throws MetadataAlreadyExistsException, SQLException {
+//        LOGGER.trace(MessageFormat.format("Inserting ActionParameterTraces {0}.", actionTraces.stream().map(ActionTrace::getMetadataKey).collect(Collectors.toList()).toString()));
+//        List<String> insertQueries = new ArrayList<>();
+//        for (ActionTrace actionTrace : actionTraces) {
+//            insertQueries.add(insertStatement(actionTrace));
+//        }
+//        getMetadataRepository().executeBatch(insertQueries);
+//    }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptDesignTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptDesignTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptDesignTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.design.ScriptDesignTrace;
 import io.metadew.iesi.metadata.definition.script.design.key.ScriptDesignTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -90,10 +88,6 @@ public class ScriptDesignTraceConfiguration extends Configuration<ScriptDesignTr
     @Override
     public void delete(ScriptDesignTraceKey scriptDesignTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptDesignTrace {0}.", scriptDesignTraceKey.toString()));
-        if (!exists(scriptDesignTraceKey)) {
-            throw new ScriptDesignTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptTrace {0} does not exists", scriptDesignTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptDesignTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -108,10 +102,6 @@ public class ScriptDesignTraceConfiguration extends Configuration<ScriptDesignTr
     @Override
     public void insert(ScriptDesignTrace scriptDesignTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptDesignParameterTrace {0}.", scriptDesignTrace.toString()));
-        if (exists(scriptDesignTrace.getMetadataKey())) {
-            throw new ScriptDesignTraceAlreadyExistsException(MessageFormat.format(
-                    "ActionParameterTrace {0} already exists", scriptDesignTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptDesignTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -136,5 +126,23 @@ public class ScriptDesignTraceConfiguration extends Configuration<ScriptDesignTr
                 SQLTools.GetStringForSQL(scriptDesignTrace.getScriptType()) + "," +
                 SQLTools.GetStringForSQL(scriptDesignTrace.getScriptName()) + "," +
                 SQLTools.GetStringForSQL(scriptDesignTrace.getScriptDescription()) + ");";
+    }
+
+    @Override
+    public void update(ScriptDesignTrace scriptDesignTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptDesignParameterTrace {0}.", scriptDesignTrace.toString()));
+        String updateStatement = updateStatement(scriptDesignTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptDesignTrace scriptDesignTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptDesignTraces") +
+                " SET PARENT_PRC_ID = " + SQLTools.GetStringForSQL(scriptDesignTrace.getParentProcessId()) + "," +
+                "SCRIPT_ID = " + SQLTools.GetStringForSQL(scriptDesignTrace.getScriptId()) + "," +
+                "SCRIPT_TYP_NM = " + SQLTools.GetStringForSQL(scriptDesignTrace.getScriptType()) + "," +
+                "SCRIPT_NM = " + SQLTools.GetStringForSQL(scriptDesignTrace.getScriptName()) + "," +
+                "SCRIPT_DSC = " + SQLTools.GetStringForSQL(scriptDesignTrace.getScriptDescription()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptDesignTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptDesignTrace.getMetadataKey().getProcessId()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
@@ -130,7 +130,7 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
         return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
                 " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getScriptParameterValue()) +
                 " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getRunId()) +
-                "AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getProcessId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getProcessId()) +
                 "AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
@@ -131,6 +131,6 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
                 " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getScriptParameterValue()) +
                 " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getRunId()) +
                 " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getProcessId()) +
-                "AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getScriptParameterName()) + ";";
+                " AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptParameterDesignTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptParameterDesignTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptParameterDesignTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.design.ScriptParameterDesignTrace;
 import io.metadew.iesi.metadata.definition.script.design.key.ScriptParameterDesignTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -41,20 +39,20 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
     @Override
     public Optional<ScriptParameterDesignTrace> get(ScriptParameterDesignTraceKey scriptParameterDesignTraceKey) {
         try {
-        String query = "SELECT SCRIPT_PAR_VAL FROM " +
-                getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
-                " WHERE " +
-                " RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getRunId()) + " AND " +
-                " PRC_ID = "  + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + ";";
-        CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
-        if (cachedRowSet.size() == 0) {
-            return Optional.empty();
-        } else if (cachedRowSet.size() > 1) {
-            LOGGER.warn(MessageFormat.format("Found multiple implementations for ActionTrace {0}. Returning first implementation", scriptParameterDesignTraceKey.toString()));
-        }
-        cachedRowSet.next();
-        return Optional.of(new ScriptParameterDesignTrace(scriptParameterDesignTraceKey,
-                cachedRowSet.getString("SCRIPT_PAR_VAL")));
+            String query = "SELECT SCRIPT_PAR_VAL FROM " +
+                    getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
+                    " WHERE " +
+                    " RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getRunId()) + " AND " +
+                    " PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + ";";
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
+            if (cachedRowSet.size() == 0) {
+                return Optional.empty();
+            } else if (cachedRowSet.size() > 1) {
+                LOGGER.warn(MessageFormat.format("Found multiple implementations for ActionTrace {0}. Returning first implementation", scriptParameterDesignTraceKey.toString()));
+            }
+            cachedRowSet.next();
+            return Optional.of(new ScriptParameterDesignTrace(scriptParameterDesignTraceKey,
+                    cachedRowSet.getString("SCRIPT_PAR_VAL")));
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -63,18 +61,18 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
     @Override
     public List<ScriptParameterDesignTrace> getAll() {
         try {
-        List<ScriptParameterDesignTrace> scriptParameterDesignTraces = new ArrayList<>();
-        String query = "SELECT RUN_ID, PRC_ID, SCRIPT_PAR_NM, SCRIPT_PAR_VAL FROM " +
-                getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") + ";";
-        CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
-        while (cachedRowSet.next()) {
-            scriptParameterDesignTraces.add(new ScriptParameterDesignTrace(new ScriptParameterDesignTraceKey(
-                    cachedRowSet.getString("RUN_ID"),
-                    cachedRowSet.getLong("PRC_ID"),
-                    cachedRowSet.getString("SCRIPT_PAR_NM")),
-                    cachedRowSet.getString("SCRIPT_PAR_VAL")));
-        }
-        return scriptParameterDesignTraces;
+            List<ScriptParameterDesignTrace> scriptParameterDesignTraces = new ArrayList<>();
+            String query = "SELECT RUN_ID, PRC_ID, SCRIPT_PAR_NM, SCRIPT_PAR_VAL FROM " +
+                    getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") + ";";
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
+            while (cachedRowSet.next()) {
+                scriptParameterDesignTraces.add(new ScriptParameterDesignTrace(new ScriptParameterDesignTraceKey(
+                        cachedRowSet.getString("RUN_ID"),
+                        cachedRowSet.getLong("PRC_ID"),
+                        cachedRowSet.getString("SCRIPT_PAR_NM")),
+                        cachedRowSet.getString("SCRIPT_PAR_VAL")));
+            }
+            return scriptParameterDesignTraces;
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -83,10 +81,6 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
     @Override
     public void delete(ScriptParameterDesignTraceKey scriptParameterDesignTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionTrace {0}.", scriptParameterDesignTraceKey.toString()));
-        if (!exists(scriptParameterDesignTraceKey)) {
-            throw new ScriptParameterDesignTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptParameterDesignTrace {0} does not exists", scriptParameterDesignTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptParameterDesignTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -96,7 +90,7 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
                 getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
                 " WHERE " +
                 " RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getRunId()) + " AND " +
-                " PRC_ID = "  + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + ";";
+                " PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + ";";
         CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
         return cachedRowSet.size() >= 1;
     }
@@ -105,17 +99,13 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
         return "DELETE FROM " + getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
                 " WHERE " +
                 " RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getRunId()) + " AND " +
-                " PRC_ID = "  + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + " AND " +
-                " SCRIPT_PAR_NM = "  + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getScriptParameterName()) + ";";
+                " PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getProcessId()) + " AND " +
+                " SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterDesignTraceKey.getScriptParameterName()) + ";";
     }
 
     @Override
     public void insert(ScriptParameterDesignTrace scriptParameterDesignTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptParameterDesignTrace {0}.", scriptParameterDesignTrace.toString()));
-        if (exists(scriptParameterDesignTrace.getMetadataKey())) {
-            throw new ScriptParameterDesignTraceAlreadyExistsException(MessageFormat.format(
-                    "ScriptParameterDesignTrace {0} already exists", scriptParameterDesignTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptParameterDesignTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -127,5 +117,20 @@ public class ScriptParameterDesignTraceConfiguration extends Configuration<Scrip
                 SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getProcessId()) + "," +
                 SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getScriptParameterName()) + "," +
                 SQLTools.GetStringForSQL(scriptParameterDesignTrace.getScriptParameterValue()) + ");";
+    }
+
+    @Override
+    public void update(ScriptParameterDesignTrace scriptParameterDesignTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptParameterDesignTrace {0}.", scriptParameterDesignTrace.toString()));
+        String updateStatement = updateStatement(scriptParameterDesignTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptParameterDesignTrace scriptParameterDesignTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptParameterDesignTraces") +
+                " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getScriptParameterValue()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getRunId()) +
+                "AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getProcessId()) +
+                "AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterDesignTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptVersionDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/design/ScriptVersionDesignTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptVersionDesignTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.design.exception.ScriptVersionDesignTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.design.ScriptVersionDesignTrace;
 import io.metadew.iesi.metadata.definition.script.design.key.ScriptVersionDesignTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -84,10 +82,6 @@ public class ScriptVersionDesignTraceConfiguration extends Configuration<ScriptV
     @Override
     public void delete(ScriptVersionDesignTraceKey scriptVersionDesignTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptVersionDesignTrace {0}.", scriptVersionDesignTraceKey.toString()));
-        if (!exists(scriptVersionDesignTraceKey)) {
-            throw new ScriptVersionDesignTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptTrace {0} does not exists", scriptVersionDesignTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptVersionDesignTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -112,10 +106,6 @@ public class ScriptVersionDesignTraceConfiguration extends Configuration<ScriptV
     @Override
     public void insert(ScriptVersionDesignTrace scriptVersionDesignTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptVersionDesignTrace {0}.", scriptVersionDesignTrace.toString()));
-        if (exists(scriptVersionDesignTrace.getMetadataKey())) {
-            throw new ScriptVersionDesignTraceAlreadyExistsException(MessageFormat.format(
-                    "ActionParameterTrace {0} already exists", scriptVersionDesignTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptVersionDesignTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -127,5 +117,20 @@ public class ScriptVersionDesignTraceConfiguration extends Configuration<ScriptV
                 SQLTools.GetStringForSQL(scriptVersionDesignTrace.getMetadataKey().getProcessId()) + "," +
                 SQLTools.GetStringForSQL(scriptVersionDesignTrace.getScriptVersionNumber()) + "," +
                 SQLTools.GetStringForSQL(scriptVersionDesignTrace.getScriptVersionDescription()) + ");";
+    }
+
+    @Override
+    public void update(ScriptVersionDesignTrace scriptVersionDesignTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptVersionDesignTrace {0}.", scriptVersionDesignTrace.toString()));
+        String updateStatement = updateStatement(scriptVersionDesignTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptVersionDesignTrace scriptVersionDesignTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptVersionDesignTraces") +
+                " SET SCRIPT_VRS_DSC = " + SQLTools.GetStringForSQL(scriptVersionDesignTrace.getScriptVersionDescription()) + ", " +
+                "SCRIPT_VRS_NB = " + SQLTools.GetStringForSQL(scriptVersionDesignTrace.getScriptVersionNumber()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptVersionDesignTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptVersionDesignTrace.getMetadataKey().getProcessId()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultConfiguration.java
@@ -146,7 +146,7 @@ public class ScriptResultConfiguration extends Configuration<ScriptResult, Scrip
                 "ST_NM = " + SQLTools.GetStringForSQL(scriptResult.getStatus()) + "," +
                 "STRT_TMS = " + SQLTools.GetStringForSQL(scriptResult.getStartTimestamp()) + "," +
                 "END_TMS = " + SQLTools.GetStringForSQL(scriptResult.getEndTimestamp()) +
-                "WHERE " +
+                " WHERE " +
                 "RUN_ID = " + SQLTools.GetStringForSQL(scriptResult.getMetadataKey().getRunId()) +
                 " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptResult.getMetadataKey().getProcessId()) + ";";
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.result.exception.ScriptResultAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.result.exception.ScriptResultDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.result.ScriptResult;
 import io.metadew.iesi.metadata.definition.script.result.key.ScriptResultKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -31,11 +29,13 @@ public class ScriptResultConfiguration extends Configuration<ScriptResult, Scrip
         return INSTANCE;
     }
 
-    private ScriptResultConfiguration() {}
+    private ScriptResultConfiguration() {
+    }
 
     public void init(MetadataRepository metadataRepository) {
         setMetadataRepository(metadataRepository);
     }
+
     @Override
     public Optional<ScriptResult> get(ScriptResultKey scriptResultKey) {
         try {
@@ -93,10 +93,6 @@ public class ScriptResultConfiguration extends Configuration<ScriptResult, Scrip
     @Override
     public void delete(ScriptResultKey scriptResultKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptResult {0}.", scriptResultKey.toString()));
-        if (!exists(scriptResultKey)) {
-            throw new ScriptResultDoesNotExistException(MessageFormat.format(
-                    "ScriptResult {0} does not exists", scriptResultKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptResultKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -111,10 +107,6 @@ public class ScriptResultConfiguration extends Configuration<ScriptResult, Scrip
     @Override
     public void insert(ScriptResult scriptResult) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptResult {0}.", scriptResult.getMetadataKey().toString()));
-        if (exists(scriptResult.getMetadataKey())) {
-            throw new ScriptResultAlreadyExistsException(MessageFormat.format(
-                    "ScriptResult {0} already exists", scriptResult.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptResult);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -135,79 +127,30 @@ public class ScriptResultConfiguration extends Configuration<ScriptResult, Scrip
                 SQLTools.GetStringForSQL(scriptResult.getEndTimestamp()) + ");";
     }
 
-//	public ScriptResult getScript(String runId) {
-//		ScriptResult scriptResult = new ScriptResult();
-//		String queryScript = "select RUN_ID, PRC_ID, PARENT_PRC_ID, SCRIPT_ID, SCRIPT_NM, SCRIPT_VRS_NB, ENV_NM, ST_NM, STRT_TMS, END_TMS from "
-//				+ getMetadataRepository()
-//						.getTableNameByLabel("ScriptResults")
-//				+ " where RUN_ID = '" + runId + "' and PARENT_PRC_ID = 0";
-//		CachedRowSet crsScriptResult = getMetadataRepository()
-//				.executeQuery(queryScript, "reader");
-//		try {
-//			while (crsScriptResult.next()) {
-//				scriptResult.setFrameworkRunId(runId);
-//				Long processId = crsScriptResult.getLong("PRC_ID");
-//				scriptResult.setProcessId(processId);
-//				scriptResult.setParentProcessId(crsScriptResult.getLong("PARENT_PRC_ID"));
-//				scriptResult.setScriptId(crsScriptResult.getString("SCRIPT_ID"));
-//				scriptResult.setScriptName(crsScriptResult.getString("SCRIPT_NM"));
-//				scriptResult.setScriptVersion(crsScriptResult.getLong("SCRIPT_VRS_NB"));
-//				scriptResult.setEnvironment(crsScriptResult.getString("ENV_NM"));
-//				scriptResult.setStatus(crsScriptResult.getString("ST_NM"));
-//				scriptResult.setStartTimestamp(crsScriptResult.getString("STRT_TMS"));
-//				scriptResult.setEndTimestamp(crsScriptResult.getString("END_TMS"));
-//				scriptResult.setScripts(this.getChildScripts(runId));
-//				scriptResult.setActions(actionResultConfiguration.getActions(runId));
-//				scriptResult.setOutputs(scriptResultOutputConfiguration.getScriptResultOutputs(runId, processId));
-//			}
-//			crsScriptResult.close();
-//		} catch (Exception e) {
-//			StringWriter StackTrace = new StringWriter();
-//			e.printStackTrace(new PrintWriter(StackTrace));
-//		}
-//
-//		if (scriptResult.getScriptName() == null || scriptResult.getScriptName().equalsIgnoreCase("")) {
-//			throw new RuntimeException("scriptresult.error.notfound");
-//		}
-//
-//		return scriptResult;
-//	}
-//
-//
-//	public List<ScriptResult> getChildScripts(String runId) {
-//		List<ScriptResult> scriptResults = new ArrayList<>();
-//		String queryScript = "select RUN_ID, PRC_ID, PARENT_PRC_ID, SCRIPT_ID, SCRIPT_NM, SCRIPT_VRS_NB, ENV_NM, ST_NM, STRT_TMS, END_TMS from "
-//				+ getMetadataRepository()
-//						.getTableNameByLabel("ScriptResults")
-//				+ " where RUN_ID = '" + runId + "' and PARENT_PRC_ID > 0";
-//		CachedRowSet crsScriptResult = getMetadataRepository()
-//				.executeQuery(queryScript, "reader");
-//		try {
-//			while (crsScriptResult.next()) {
-//				ScriptResult scriptResult = new ScriptResult();
-//				scriptResult.setFrameworkRunId(runId);
-//				Long processId = crsScriptResult.getLong("PRC_ID");
-//				scriptResult.setProcessId(processId);
-//				scriptResult.setParentProcessId(crsScriptResult.getLong("PARENT_PRC_ID"));
-//				scriptResult.setScriptId(crsScriptResult.getString("SCRIPT_ID"));
-//				scriptResult.setScriptName(crsScriptResult.getString("SCRIPT_NM"));
-//				scriptResult.setScriptVersion(crsScriptResult.getLong("SCRIPT_VRS_NB"));
-//				scriptResult.setEnvironment(crsScriptResult.getString("ENV_NM"));
-//				scriptResult.setStatus(crsScriptResult.getString("ST_NM"));
-//				scriptResult.setStartTimestamp(crsScriptResult.getString("STRT_TMS"));
-//				scriptResult.setEndTimestamp(crsScriptResult.getString("END_TMS"));
-//				scriptResult.setOutputs(scriptResultOutputConfiguration.getScriptResultOutputs(runId, processId));
-//				scriptResult.setActions(actionResultConfiguration.getActions(runId, processId));
-//
-//				scriptResults.add(scriptResult);
-//			}
-//			crsScriptResult.close();
-//		} catch (Exception e) {
-//			StringWriter StackTrace = new StringWriter();
-//			e.printStackTrace(new PrintWriter(StackTrace));
-//		}
-//
-//		return scriptResults;
-//	}
+    @Override
+    public void update(ScriptResult scriptResult) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptResult {0}.", scriptResult.getMetadataKey().toString()));
+        String updateStatement = updateStatement(scriptResult);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptResult scriptResult) {
+        return "UPDATE "
+                + getMetadataRepository().getTableNameByLabel("ScriptResults")
+                + " SET " +
+                "PARENT_PRC_ID = " + SQLTools.GetStringForSQL(scriptResult.getParentProcessId()) + "," +
+                "SCRIPT_ID = " + SQLTools.GetStringForSQL(scriptResult.getScriptId()) + "," +
+                "SCRIPT_NM = " + SQLTools.GetStringForSQL(scriptResult.getScriptName()) + "," +
+                "SCRIPT_VRS_NB = " + SQLTools.GetStringForSQL(scriptResult.getScriptVersion()) + "," +
+                "ENV_NM = " + SQLTools.GetStringForSQL(scriptResult.getEnvironment()) + "," +
+                "ST_NM = " + SQLTools.GetStringForSQL(scriptResult.getStatus()) + "," +
+                "STRT_TMS = " + SQLTools.GetStringForSQL(scriptResult.getStartTimestamp()) + "," +
+                "END_TMS = " + SQLTools.GetStringForSQL(scriptResult.getEndTimestamp()) +
+                "WHERE " +
+                "RUN_ID = " + SQLTools.GetStringForSQL(scriptResult.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptResult.getMetadataKey().getProcessId()) + ";";
+
+
+    }
 
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultOutputConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/result/ScriptResultOutputConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.result.exception.ScriptResultOutputAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.result.exception.ScriptResultOutputDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.result.ScriptResultOutput;
 import io.metadew.iesi.metadata.definition.script.result.key.ScriptResultOutputKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -83,10 +81,6 @@ public class ScriptResultOutputConfiguration extends Configuration<ScriptResultO
     @Override
     public void delete(ScriptResultOutputKey scriptResultOutputKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptResultOutput {0}.", scriptResultOutputKey.toString()));
-        if (!exists(scriptResultOutputKey)) {
-            throw new ScriptResultOutputDoesNotExistException(MessageFormat.format(
-                    "ActionResultOutput {0} does not exists", scriptResultOutputKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptResultOutputKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -102,10 +96,6 @@ public class ScriptResultOutputConfiguration extends Configuration<ScriptResultO
     @Override
     public void insert(ScriptResultOutput scriptResultOutput) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptResultOutput {0}.", scriptResultOutput.getMetadataKey().toString()));
-        if (exists(scriptResultOutput.getMetadataKey())) {
-            throw new ScriptResultOutputAlreadyExistsException(MessageFormat.format(
-                    "ActionResult {0} already exists", scriptResultOutput.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptResultOutput);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -119,6 +109,22 @@ public class ScriptResultOutputConfiguration extends Configuration<ScriptResultO
                 + SQLTools.GetStringForSQL(scriptResultOutput.getScriptId()) + ","
                 + SQLTools.GetStringForSQL(scriptResultOutput.getMetadataKey().getOutputName()) + ","
                 + SQLTools.GetStringForSQL(scriptResultOutput.getValue()) + ");";
+    }
+
+    @Override
+    public void update(ScriptResultOutput scriptResultOutput) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptResultOutput {0}.", scriptResultOutput.getMetadataKey().toString()));
+        String updateStatement = updateStatement(scriptResultOutput);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptResultOutput scriptResultOutput) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptResultOutputs")
+                + " SET SCRIPT_ID = " + SQLTools.GetStringForSQL(scriptResultOutput.getScriptId()) + "," +
+                " OUT_VAL = " + SQLTools.GetStringForSQL(scriptResultOutput.getValue()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptResultOutput.getMetadataKey().getRunId()) +
+                " AND PRC_ID =" + SQLTools.GetStringForSQL(scriptResultOutput.getMetadataKey().getProcessId()) +
+                " AND OUT_NM = " + SQLTools.GetStringForSQL(scriptResultOutput.getMetadataKey().getOutputName()) + ";";
     }
 
     public List<ScriptResultOutput> getByRunId(String runId) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
@@ -121,7 +121,7 @@ public class ScriptParameterTraceConfiguration extends Configuration<ScriptParam
         return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptParameterTraces") +
                 " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterTrace.getScriptParameterValue()) +
                 " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getRunId()) +
-                "AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getProcessId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getProcessId()) +
                 " AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptParameterTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptParameterTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.trace.ScriptParameterTrace;
 import io.metadew.iesi.metadata.definition.script.trace.key.ScriptParameterTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -84,10 +82,6 @@ public class ScriptParameterTraceConfiguration extends Configuration<ScriptParam
     @Override
     public void delete(ScriptParameterTraceKey scriptParameterTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptParameterTrace {0}.", scriptParameterTraceKey.toString()));
-        if (!exists(scriptParameterTraceKey)) {
-            throw new ScriptParameterTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptParameterTrace {0} does not exists", scriptParameterTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptParameterTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -103,10 +97,6 @@ public class ScriptParameterTraceConfiguration extends Configuration<ScriptParam
     @Override
     public void insert(ScriptParameterTrace scriptParameterTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptParameterTrace {0}.", scriptParameterTrace.getMetadataKey().toString()));
-        if (exists(scriptParameterTrace.getMetadataKey())) {
-            throw new ScriptParameterTraceAlreadyExistsException(MessageFormat.format(
-                    "ScriptParameterTrace {0} already exists", scriptParameterTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptParameterTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -118,5 +108,20 @@ public class ScriptParameterTraceConfiguration extends Configuration<ScriptParam
                 SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getProcessId()) + "," +
                 SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getScriptParameterName()) + "," +
                 SQLTools.GetStringForSQL(scriptParameterTrace.getScriptParameterValue()) + ");";
+    }
+
+    @Override
+    public void update(ScriptParameterTrace scriptParameterTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptParameterTrace {0}.", scriptParameterTrace.toString()));
+        String updateStatement = updateStatement(scriptParameterTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptParameterTrace scriptParameterTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptParameterTraces") +
+                " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterTrace.getScriptParameterValue()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getRunId()) +
+                "AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getProcessId()) +
+                "AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptParameterTraceConfiguration.java
@@ -122,6 +122,6 @@ public class ScriptParameterTraceConfiguration extends Configuration<ScriptParam
                 " SET SCRIPT_PAR_VAL = " + SQLTools.GetStringForSQL(scriptParameterTrace.getScriptParameterValue()) +
                 " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getRunId()) +
                 "AND PRC_ID = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getProcessId()) +
-                "AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getScriptParameterName()) + ";";
+                " AND SCRIPT_PAR_NM = " + SQLTools.GetStringForSQL(scriptParameterTrace.getMetadataKey().getScriptParameterName()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.trace.ScriptTrace;
 import io.metadew.iesi.metadata.definition.script.trace.key.ScriptTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -91,10 +89,6 @@ public class ScriptTraceConfiguration extends Configuration<ScriptTrace, ScriptT
     @Override
     public void delete(ScriptTraceKey scriptTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ActionTrace {0}.", scriptTraceKey.toString()));
-        if (!exists(scriptTraceKey)) {
-            throw new ScriptTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptTrace {0} does not exists", scriptTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -109,10 +103,6 @@ public class ScriptTraceConfiguration extends Configuration<ScriptTrace, ScriptT
     @Override
     public void insert(ScriptTrace scriptTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting ScriptTrace {0}.", scriptTrace.getMetadataKey().toString()));
-        if (exists(scriptTrace.getMetadataKey())) {
-            throw new ScriptTraceAlreadyExistsException(MessageFormat.format(
-                    "ScriptTrace {0} already exists", scriptTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -127,5 +117,23 @@ public class ScriptTraceConfiguration extends Configuration<ScriptTrace, ScriptT
                 SQLTools.GetStringForSQL(scriptTrace.getScriptType()) + "," +
                 SQLTools.GetStringForSQL(scriptTrace.getScriptName()) + "," +
                 SQLTools.GetStringForSQL(scriptTrace.getScriptDescription()) + ");";
+    }
+
+    @Override
+    public void update(ScriptTrace scriptTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptTrace {0}.", scriptTrace.toString()));
+        String updateStatement = updateStatement(scriptTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptTrace scriptTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptTraces") +
+                " SET PARENT_PRC_ID = " + SQLTools.GetStringForSQL(scriptTrace.getParentProcessId()) + "," +
+                "SCRIPT_ID = " + SQLTools.GetStringForSQL(scriptTrace.getScriptId()) + "," +
+                "SCRIPT_TYP_NM = " + SQLTools.GetStringForSQL(scriptTrace.getScriptType()) + "," +
+                "SCRIPT_NM = " + SQLTools.GetStringForSQL(scriptTrace.getScriptName()) + "," +
+                "SCRIPT_DSC = " + SQLTools.GetStringForSQL(scriptTrace.getScriptDescription()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptTrace.getMetadataKey().getProcessId()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptVersionTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/trace/ScriptVersionTraceConfiguration.java
@@ -4,8 +4,6 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptVersionTraceAlreadyExistsException;
-import io.metadew.iesi.metadata.configuration.script.trace.exception.ScriptVersionTraceDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.trace.ScriptVersionTrace;
 import io.metadew.iesi.metadata.definition.script.trace.key.ScriptVersionTraceKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
@@ -84,10 +82,6 @@ public class ScriptVersionTraceConfiguration extends Configuration<ScriptVersion
     @Override
     public void delete(ScriptVersionTraceKey scriptVersionTraceKey) throws MetadataDoesNotExistException {
         LOGGER.trace(MessageFormat.format("Deleting ScriptVersionTrace {0}.", scriptVersionTraceKey.toString()));
-        if (!exists(scriptVersionTraceKey)) {
-            throw new ScriptVersionTraceDoesNotExistException(MessageFormat.format(
-                    "ScriptVersionTrace {0} does not exists", scriptVersionTraceKey.toString()));
-        }
         String deleteStatement = deleteStatement(scriptVersionTraceKey);
         getMetadataRepository().executeUpdate(deleteStatement);
     }
@@ -102,10 +96,6 @@ public class ScriptVersionTraceConfiguration extends Configuration<ScriptVersion
     @Override
     public void insert(ScriptVersionTrace scriptVersionTrace) throws MetadataAlreadyExistsException {
         LOGGER.trace(MessageFormat.format("Inserting scriptVersionTrace {0}.", scriptVersionTrace.getMetadataKey().toString()));
-        if (exists(scriptVersionTrace.getMetadataKey())) {
-            throw new ScriptVersionTraceAlreadyExistsException(MessageFormat.format(
-                    "ScriptVersionTrace {0} already exists", scriptVersionTrace.getMetadataKey().toString()));
-        }
         String insertStatement = insertStatement(scriptVersionTrace);
         getMetadataRepository().executeUpdate(insertStatement);
     }
@@ -117,5 +107,20 @@ public class ScriptVersionTraceConfiguration extends Configuration<ScriptVersion
                 SQLTools.GetStringForSQL(scriptVersionTrace.getMetadataKey().getProcessId()) + "," +
                 SQLTools.GetStringForSQL(scriptVersionTrace.getScriptVersionNumber()) + "," +
                 SQLTools.GetStringForSQL(scriptVersionTrace.getScriptVersionDescription()) + ");";
+    }
+
+    @Override
+    public void update(ScriptVersionTrace scriptVersionTrace) {
+        LOGGER.trace(MessageFormat.format("Updating ScriptVersionTrace {0}.", scriptVersionTrace.toString()));
+        String updateStatement = updateStatement(scriptVersionTrace);
+        getMetadataRepository().executeUpdate(updateStatement);
+    }
+
+    private String updateStatement(ScriptVersionTrace scriptVersionTrace) {
+        return "UPDATE " + getMetadataRepository().getTableNameByLabel("ScriptVersionTraces") +
+                " SET SCRIPT_VRS_DSC = " + SQLTools.GetStringForSQL(scriptVersionTrace.getScriptVersionDescription()) + ", " +
+                "SCRIPT_VRS_NB = " + SQLTools.GetStringForSQL(scriptVersionTrace.getScriptVersionNumber()) +
+                " WHERE RUN_ID = " + SQLTools.GetStringForSQL(scriptVersionTrace.getMetadataKey().getRunId()) +
+                " AND PRC_ID = " + SQLTools.GetStringForSQL(scriptVersionTrace.getMetadataKey().getProcessId()) + ";";
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/MetadataField.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/MetadataField.java
@@ -11,10 +11,22 @@ public class MetadataField {
     private int length;
     private String nullable = "Y";
     private String defaultTimestamp = "N";
+    private boolean primaryKey = false;
 
     //Constructors
     public MetadataField() {
 
+    }
+
+    public MetadataField(String name, String description, int order, String type, int length, String nullable, String defaultTimestamp, boolean primaryKey) {
+        this.name = name;
+        this.description = description;
+        this.order = order;
+        this.type = type;
+        this.length = length;
+        this.nullable = nullable;
+        this.defaultTimestamp = defaultTimestamp;
+        this.primaryKey = primaryKey;
     }
 
     //Getters and Setters
@@ -75,4 +87,11 @@ public class MetadataField {
     }
 
 
+    public boolean isPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(boolean primaryKey) {
+        this.primaryKey = primaryKey;
+    }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/action/performance/ActionPerformance.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/action/performance/ActionPerformance.java
@@ -7,24 +7,19 @@ import java.time.LocalDateTime;
 
 public class ActionPerformance extends Metadata<ActionPerformanceKey> {
 
-    private ActionPerformanceKey actionPerformanceKey;
-
     private String context;
+    private String actionId;
     private LocalDateTime startTimestamp;
     private LocalDateTime endTimestamp;
     private Double duration;
 
-    public ActionPerformance(ActionPerformanceKey actionPerformanceKey, String context, LocalDateTime startTimestamp, LocalDateTime stopTimestamp, Double duration) {
+    public ActionPerformance(ActionPerformanceKey actionPerformanceKey, String context, String actionId, LocalDateTime startTimestamp, LocalDateTime stopTimestamp, Double duration) {
         super(actionPerformanceKey);
-        this.actionPerformanceKey = actionPerformanceKey;
         this.context = context;
+        this.actionId = actionId;
         this.startTimestamp = startTimestamp;
         this.endTimestamp = stopTimestamp;
         this.duration = duration;
-    }
-
-    public ActionPerformanceKey getActionPerformanceKey() {
-        return actionPerformanceKey;
     }
 
     public String getContext() {
@@ -42,4 +37,9 @@ public class ActionPerformance extends Metadata<ActionPerformanceKey> {
     public Double getDuration() {
         return duration;
     }
+
+    public String getActionId() {
+        return actionId;
+    }
+
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/action/performance/key/ActionPerformanceKey.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/action/performance/key/ActionPerformanceKey.java
@@ -6,13 +6,11 @@ public class ActionPerformanceKey extends MetadataKey {
 
     private String runId;
     private Long procedureId;
-    private String actionId;
     private String scope;
 
-    public ActionPerformanceKey(String runId, Long procedureId, String actionId, String scope) {
+    public ActionPerformanceKey(String runId, Long procedureId, String scope) {
         this.runId = runId;
         this.procedureId = procedureId;
-        this.actionId = actionId;
         this.scope = scope;
     }
 
@@ -22,10 +20,6 @@ public class ActionPerformanceKey extends MetadataKey {
 
     public Long getProcedureId() {
         return procedureId;
-    }
-
-    public String getActionId() {
-        return actionId;
     }
 
     public String getScope() {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/repository/ResultMetadataRepository.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/repository/ResultMetadataRepository.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.metadew.iesi.metadata.configuration.action.performance.ActionPerformanceConfiguration;
 import io.metadew.iesi.metadata.configuration.action.result.ActionResultConfiguration;
 import io.metadew.iesi.metadata.configuration.action.result.ActionResultOutputConfiguration;
-import io.metadew.iesi.metadata.configuration.request.RequestResultConfiguration;
 import io.metadew.iesi.metadata.configuration.script.result.ScriptResultConfiguration;
 import io.metadew.iesi.metadata.configuration.script.result.ScriptResultOutputConfiguration;
 import io.metadew.iesi.metadata.definition.DataObject;
@@ -24,7 +23,6 @@ public class ResultMetadataRepository extends MetadataRepository {
         ActionResultOutputConfiguration.getInstance().init(this);
         ScriptResultOutputConfiguration.getInstance().init(this);
         ActionPerformanceConfiguration.getInstance().init(this);
-        RequestResultConfiguration.getInstance().init(this);
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/repository/TraceMetadataRepository.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/repository/TraceMetadataRepository.java
@@ -26,13 +26,13 @@ public class TraceMetadataRepository extends MetadataRepository {
         ScriptDesignTraceConfiguration.getInstance().init(this);
         ScriptVersionDesignTraceConfiguration.getInstance().init(this);
         ScriptParameterDesignTraceConfiguration.getInstance().init(this);
-        ActionTraceConfiguration.getInstance().init(this);
         ScriptTraceConfiguration.getInstance().init(this);
         ScriptVersionTraceConfiguration.getInstance().init(this);
         ScriptParameterTraceConfiguration.getInstance().init(this);
+        ActionTraceConfiguration.getInstance().init(this);
+        ActionParameterTraceConfiguration.getInstance().init(this);
         ActionDesignTraceConfiguration.getInstance().init(this);
         ActionParameterDesignTraceConfiguration.getInstance().init(this);
-        ActionParameterTraceConfiguration.getInstance().init(this);
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/script/ScriptDesignTraceService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/script/ScriptDesignTraceService.java
@@ -42,9 +42,6 @@ public class ScriptDesignTraceService {
                 ScriptParameterDesignTraceConfiguration.getInstance().insert(new ScriptParameterDesignTrace(runId, processId, scriptParameter));
             }
 
-//            for (Action action : script.getActions()) {
-//                actionDesignTraceService.trace(runId, processId, action);
-//            }
         } catch (MetadataAlreadyExistsException e) {
             StringWriter StackTrace = new StringWriter();
             e.printStackTrace(new PrintWriter(StackTrace));

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/script/ScriptDesignTraceService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/script/ScriptDesignTraceService.java
@@ -42,9 +42,9 @@ public class ScriptDesignTraceService {
                 ScriptParameterDesignTraceConfiguration.getInstance().insert(new ScriptParameterDesignTrace(runId, processId, scriptParameter));
             }
 
-            for (Action action : script.getActions()) {
-                actionDesignTraceService.trace(runId, processId, action);
-            }
+//            for (Action action : script.getActions()) {
+//                actionDesignTraceService.trace(runId, processId, action);
+//            }
         } catch (MetadataAlreadyExistsException e) {
             StringWriter StackTrace = new StringWriter();
             e.printStackTrace(new PrintWriter(StackTrace));

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/socket/SocketTransmitMessage.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/socket/SocketTransmitMessage.java
@@ -5,7 +5,6 @@ import io.metadew.iesi.datatypes.DataType;
 import io.metadew.iesi.datatypes.dataset.Dataset;
 import io.metadew.iesi.datatypes.text.Text;
 import io.metadew.iesi.framework.configuration.FrameworkSettingConfiguration;
-import io.metadew.iesi.framework.definition.FrameworkSetting;
 import io.metadew.iesi.framework.execution.FrameworkControl;
 import io.metadew.iesi.metadata.configuration.connection.ConnectionConfiguration;
 import io.metadew.iesi.metadata.definition.action.ActionParameter;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ActionExecution.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ActionExecution.java
@@ -2,6 +2,8 @@ package io.metadew.iesi.script.execution;
 
 import io.metadew.iesi.metadata.configuration.type.ActionTypeConfiguration;
 import io.metadew.iesi.metadata.definition.action.Action;
+import io.metadew.iesi.metadata.definition.action.design.ActionDesignTrace;
+import io.metadew.iesi.metadata.service.action.ActionDesignTraceService;
 import io.metadew.iesi.script.configuration.IterationInstance;
 import io.metadew.iesi.script.operation.ActionParameterOperation;
 import io.metadew.iesi.script.operation.ComponentAttributeOperation;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ActionPerformanceLogger.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ActionPerformanceLogger.java
@@ -15,8 +15,8 @@ public class ActionPerformanceLogger {
 
     public void log(ActionExecution actionExecution, String scope, LocalDateTime startTimestamp, LocalDateTime endTimestalmp) {
         try {
-            ActionPerformanceConfiguration.getInstance().insert(new ActionPerformance(new ActionPerformanceKey(actionExecution.getExecutionControl().getRunId(), actionExecution.getProcessId(), actionExecution.getAction().getId(), scope),
-                    actionExecution.getExecutionControl().getEnvName(), startTimestamp, endTimestalmp, (double) Duration.between(startTimestamp, endTimestalmp).toMillis()));
+            ActionPerformanceConfiguration.getInstance().insert(new ActionPerformance(new ActionPerformanceKey(actionExecution.getExecutionControl().getRunId(), actionExecution.getProcessId(), scope),
+                    actionExecution.getExecutionControl().getEnvName(), actionExecution.getAction().getId(), startTimestamp, endTimestalmp, (double) Duration.between(startTimestamp, endTimestalmp).toMillis()));
         } catch (ActionPerformanceAlreadyExistsException e) {
             e.printStackTrace();
         }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ExecutionControl.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ExecutionControl.java
@@ -28,6 +28,7 @@ import io.metadew.iesi.metadata.definition.script.result.key.ScriptResultKey;
 import io.metadew.iesi.metadata.definition.script.result.key.ScriptResultOutputKey;
 import io.metadew.iesi.metadata.execution.MetadataControl;
 import io.metadew.iesi.metadata.restore.RestoreExecution;
+import io.metadew.iesi.metadata.service.action.ActionDesignTraceService;
 import io.metadew.iesi.metadata.service.script.ScriptDesignTraceService;
 import org.apache.logging.log4j.*;
 
@@ -43,6 +44,7 @@ import java.util.UUID;
 public class ExecutionControl {
 
     private final DelimitedFileBeatElasticSearchConnection elasticSearchConnection;
+    private final ActionDesignTraceService actionDesignTraceService;
     private ExecutionRuntime executionRuntime;
     private ExecutionLog executionLog;
     private ExecutionTrace executionTrace;
@@ -63,6 +65,7 @@ public class ExecutionControl {
     public ExecutionControl() throws ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, InstantiationException, IllegalAccessException, SQLException {
         this.scriptDesignTraceService = new ScriptDesignTraceService();
+        this.actionDesignTraceService = new ActionDesignTraceService();
         this.executionLog = new ExecutionLog();
         this.executionTrace = new ExecutionTrace();
         initializeRunId();
@@ -133,6 +136,7 @@ public class ExecutionControl {
 
     public void logStart(ActionExecution actionExecution) {
         try {
+            actionDesignTraceService.trace(runId, actionExecution.getProcessId(), actionExecution.getAction());
             ActionResult actionResult = new ActionResult(
                     runId,
                     actionExecution.getProcessId(),

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/math/Substraction.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/math/Substraction.java
@@ -1,10 +1,5 @@
 package io.metadew.iesi.script.execution.instruction.data.math;
 
-import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
-
-import java.util.Arrays;
-import java.util.List;
-
 public class Substraction extends BinaryArithmeticOperation{
 
     @Override

--- a/core/java/iesi-rest-without-microservices/pom.xml
+++ b/core/java/iesi-rest-without-microservices/pom.xml
@@ -13,7 +13,7 @@
     <packaging>${packaging.type}</packaging>
     <groupId>io.metadew.iesi</groupId>
     <artifactId>iesi-rest</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <name>IesiRestApplicationWithoutMicroServices</name>
     <description>IESI REST API</description>
 
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>io.metadew</groupId>
             <artifactId>iesi-core</artifactId>
-            <version>0.2.0</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/java/iesi-test/pom.xml
+++ b/core/java/iesi-test/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.metadew</groupId>
     <artifactId>iesi-test</artifactId>
-    <version>0.1.0</version>
+    <version>0.3.0</version>
 
 
     <properties>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.metadew</groupId>
             <artifactId>iesi-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/core/metadata/def/Result/Tables/RES_ACTION.yml
+++ b/core/metadata/def/Result/Tables/RES_ACTION.yml
@@ -15,6 +15,7 @@ data:
     length: "255"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PRC_ID"
     description: "Process number for the action execution"
     order: "2"
@@ -22,6 +23,7 @@ data:
     length: "0"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "SCRIPT_PRC_ID"
     description: "Process number for the script execution"
     order: "3"

--- a/core/metadata/def/Result/Tables/RES_ACTION_OUT.yml
+++ b/core/metadata/def/Result/Tables/RES_ACTION_OUT.yml
@@ -15,6 +15,7 @@ data:
     length: "255"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PRC_ID"
     description: "Process number for the action within the script execution"
     order: "2"
@@ -22,6 +23,7 @@ data:
     length: "0"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "ACTION_ID"
     description: "Unique identifier for the action design"
     order: "3"
@@ -36,6 +38,7 @@ data:
     length: "100"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "OUT_VAL"
     description: "String type output value"
     order: "5"

--- a/core/metadata/def/Result/Tables/RES_ACTION_PERF.yml
+++ b/core/metadata/def/Result/Tables/RES_ACTION_PERF.yml
@@ -15,6 +15,7 @@ data:
     length: "255"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PRC_ID"
     description: "Process number for the action within the script execution"
     order: "2"
@@ -22,6 +23,7 @@ data:
     length: "0"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "ACTION_ID"
     description: "Unique identifier for the action design"
     order: "3"
@@ -43,6 +45,7 @@ data:
     length: "200"
     nullable: "Y"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "STRT_TMS"
     description: "Starting timestamp for the performance entry"
     order: "6"

--- a/core/metadata/def/Result/Tables/RES_SCRIPT.yml
+++ b/core/metadata/def/Result/Tables/RES_SCRIPT.yml
@@ -15,6 +15,7 @@ data:
     length: "255"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PRC_ID"
     description: "Process number for the script execution"
     order: "1"
@@ -22,6 +23,7 @@ data:
     length: "0"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PARENT_PRC_ID"
     description: "Process number for the parent executing the script"
     order: "2"

--- a/core/metadata/def/Result/Tables/RES_SCRIPT_OUT.yml
+++ b/core/metadata/def/Result/Tables/RES_SCRIPT_OUT.yml
@@ -15,6 +15,7 @@ data:
     length: "255"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "PRC_ID"
     description: "Process number for the script within the script execution"
     order: "2"
@@ -22,6 +23,7 @@ data:
     length: "0"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "SCRIPT_ID"
     description: "Unique identifier for the script design"
     order: "3"
@@ -36,6 +38,7 @@ data:
     length: "100"
     nullable: "N"
     defaultTimestamp: ""
+    primaryKey: true
   - name: "OUT_VAL"
     description: "String type output value"
     order: "5"

--- a/core/metadata/def/ResultTables.json
+++ b/core/metadata/def/ResultTables.json
@@ -14,7 +14,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -22,7 +23,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PRC_ID",
       "description" : "Process number for the script execution",
@@ -98,7 +100,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action within the script execution",
@@ -106,7 +109,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -122,7 +126,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "OUT_VAL",
       "description" : "String type output value",
@@ -158,7 +163,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action within the script execution",
@@ -166,7 +172,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -190,7 +197,8 @@
       "type" : "string",
       "length" : "200",
       "nullable" : "Y",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "STRT_TMS",
       "description" : "Starting timestamp for the performance entry",
@@ -350,7 +358,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -358,7 +367,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -442,7 +452,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script within the script execution",
@@ -450,7 +461,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_ID",
       "description" : "Unique identifier for the script design",
@@ -466,7 +478,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "OUT_VAL",
       "description" : "String type output value",

--- a/core/metadata/def/Trace/Tables/TRC_ACTION.yml
+++ b/core/metadata/def/Trace/Tables/TRC_ACTION.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the action execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_ID
       description: Unique identifier for the action design
       order: '3'

--- a/core/metadata/def/Trace/Tables/TRC_ACTION_PAR.yml
+++ b/core/metadata/def/Trace/Tables/TRC_ACTION_PAR.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the action execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_ID
       description: Unique identifier for the action design
       order: '3'
@@ -37,6 +39,7 @@ data:
       length: '100'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_PAR_VAL
       description: String type parameter value
       order: '5'

--- a/core/metadata/def/Trace/Tables/TRC_DES_ACTION.yml
+++ b/core/metadata/def/Trace/Tables/TRC_DES_ACTION.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the action execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_ID
       description: Unique identifier for the action design
       order: '5'

--- a/core/metadata/def/Trace/Tables/TRC_DES_ACTION_PAR.yml
+++ b/core/metadata/def/Trace/Tables/TRC_DES_ACTION_PAR.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the action execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_ID
       description: Unique identifier for the action design
       order: '5'
@@ -37,6 +39,7 @@ data:
       length: '100'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: ACTION_PAR_VAL
       description: String type parameter value
       order: '7'

--- a/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT.yml
+++ b/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PARENT_PRC_ID
       description: Process number for the parent executing the script
       order: '3'

--- a/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT_PAR.yml
+++ b/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT_PAR.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_PAR_NM
       description: Name of the script parameter
       order: '5'
@@ -30,6 +32,7 @@ data:
       length: '100'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_PAR_VAL
       description: String type parameter value
       order: '6'

--- a/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT_VRS.yml
+++ b/core/metadata/def/Trace/Tables/TRC_DES_SCRIPT_VRS.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_VRS_NB
       description: Unique identifier for the script version
       order: '4'

--- a/core/metadata/def/Trace/Tables/TRC_SCRIPT.yml
+++ b/core/metadata/def/Trace/Tables/TRC_SCRIPT.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PARENT_PRC_ID
       description: Process number for the parent executing the script
       order: '3'

--- a/core/metadata/def/Trace/Tables/TRC_SCRIPT_PAR.yml
+++ b/core/metadata/def/Trace/Tables/TRC_SCRIPT_PAR.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_PAR_NM
       description: Name of the script parameter
       order: '4'
@@ -30,6 +32,7 @@ data:
       length: '100'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_PAR_VAL
       description: String type parameter value
       order: '5'

--- a/core/metadata/def/Trace/Tables/TRC_SCRIPT_VRS.yml
+++ b/core/metadata/def/Trace/Tables/TRC_SCRIPT_VRS.yml
@@ -16,6 +16,7 @@ data:
       length: '255'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: PRC_ID
       description: Process number for the script execution
       order: '2'
@@ -23,6 +24,7 @@ data:
       length: '0'
       nullable: N
       defaultTimestamp: ''
+      primaryKey: true
     - name: SCRIPT_VRS_NB
       description: Unique identifier for the script version
       order: '4'

--- a/core/metadata/def/TraceTables.json
+++ b/core/metadata/def/TraceTables.json
@@ -14,7 +14,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -22,7 +23,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -138,7 +140,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -146,7 +149,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -162,7 +166,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_PAR_VAL",
       "description" : "String type parameter value",
@@ -198,7 +203,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -206,7 +212,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -322,7 +329,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -330,7 +338,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -346,7 +355,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_PAR_VAL",
       "description" : "String type parameter value",
@@ -382,7 +392,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -390,7 +401,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -458,7 +470,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -466,7 +479,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_NM",
       "description" : "Name of the script parameter",
@@ -474,7 +488,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_VAL",
       "description" : "String type parameter value",
@@ -510,7 +525,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -518,7 +534,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_VRS_NB",
       "description" : "Unique identifier for the script version",
@@ -562,7 +579,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -570,7 +588,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -638,7 +657,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -646,7 +666,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_NM",
       "description" : "Name of the script parameter",
@@ -654,7 +675,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_VAL",
       "description" : "String type parameter value",
@@ -690,7 +712,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -698,7 +721,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_VRS_NB",
       "description" : "Unique identifier for the script version",

--- a/docs/_data/datamodel/ResultTables.json
+++ b/docs/_data/datamodel/ResultTables.json
@@ -14,7 +14,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -22,7 +23,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PRC_ID",
       "description" : "Process number for the script execution",
@@ -98,7 +100,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action within the script execution",
@@ -106,7 +109,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -122,7 +126,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "OUT_VAL",
       "description" : "String type output value",
@@ -158,7 +163,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action within the script execution",
@@ -166,7 +172,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -190,7 +197,8 @@
       "type" : "string",
       "length" : "200",
       "nullable" : "Y",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "STRT_TMS",
       "description" : "Starting timestamp for the performance entry",
@@ -350,7 +358,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -358,7 +367,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -442,7 +452,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script within the script execution",
@@ -450,7 +461,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_ID",
       "description" : "Unique identifier for the script design",
@@ -466,7 +478,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "OUT_VAL",
       "description" : "String type output value",

--- a/docs/_data/datamodel/TraceTables.json
+++ b/docs/_data/datamodel/TraceTables.json
@@ -14,7 +14,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -22,7 +23,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -138,7 +140,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -146,7 +149,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -162,7 +166,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_PAR_VAL",
       "description" : "String type parameter value",
@@ -198,7 +203,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -206,7 +212,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -322,7 +329,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the action execution",
@@ -330,7 +338,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_ID",
       "description" : "Unique identifier for the action design",
@@ -346,7 +355,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "ACTION_PAR_VAL",
       "description" : "String type parameter value",
@@ -382,7 +392,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -390,7 +401,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -458,7 +470,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -466,7 +479,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_NM",
       "description" : "Name of the script parameter",
@@ -474,7 +488,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_VAL",
       "description" : "String type parameter value",
@@ -510,7 +525,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -518,7 +534,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_VRS_NB",
       "description" : "Unique identifier for the script version",
@@ -562,7 +579,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -570,7 +588,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PARENT_PRC_ID",
       "description" : "Process number for the parent executing the script",
@@ -638,7 +657,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -646,7 +666,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_NM",
       "description" : "Name of the script parameter",
@@ -654,7 +675,8 @@
       "type" : "string",
       "length" : "100",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_PAR_VAL",
       "description" : "String type parameter value",
@@ -690,7 +712,8 @@
       "type" : "string",
       "length" : "255",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "PRC_ID",
       "description" : "Process number for the script execution",
@@ -698,7 +721,8 @@
       "type" : "number",
       "length" : "0",
       "nullable" : "N",
-      "defaultTimestamp" : ""
+      "defaultTimestamp" : "",
+      "primaryKey" : true
     }, {
       "name" : "SCRIPT_VRS_NB",
       "description" : "Unique identifier for the script version",


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Due to the potential size of the result and trace repository, the omission of the primary keys at DB level can cause performance penalties.

**Describe the solution you'd like**
Enable the primary keys of all tables under the trace and result repository. This should be done through execution of the command `./iesi-metadata.sh -create ...`

**id**
f014fbd