### PR TITLE
use bash source for current dir

### DIFF
--- a/core/bin/iesi-encrypt.sh
+++ b/core/bin/iesi-encrypt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-current_dir=$(pwd)
+current_dir=$(dirname "${BASH_SOURCE[0]}")
 lib_dir=$current_dir/../lib
 
 classpath="*"

--- a/core/bin/iesi-launch.sh
+++ b/core/bin/iesi-launch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-current_dir=$(pwd)
+current_dir=$(dirname "${BASH_SOURCE[0]}")
 lib_dir=$current_dir/../lib
 
 classpath="*"

--- a/core/bin/iesi-metadata.sh
+++ b/core/bin/iesi-metadata.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-current_dir=$(pwd)
+current_dir=$(dirname "${BASH_SOURCE[0]}")
 lib_dir=$current_dir/../lib
 
 classpath="*"

--- a/core/bin/iesi-rest.sh
+++ b/core/bin/iesi-rest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-current_dir=$(pwd)
+current_dir=$(dirname "${BASH_SOURCE[0]}")
 lib_dir=$current_dir/../rest
 
 cd $lib_dir

--- a/core/bin/iesi-server.sh
+++ b/core/bin/iesi-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-current_dir=$(pwd)
+current_dir=$(dirname "${BASH_SOURCE[0]}")
 lib_dir=$current_dir/../lib
 
 classpath="*"


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When using the .sh scripts in a service file, the service will not start because the current_dir uses $(pwd) and that is not the directory where the script is located.
Using BASH_SOURCE will make sure the script works no matter where you start it from.