### PR TITLE
Addition to {{*number.between()}} function

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,14 @@
+---
+name: Documentation Request
+about: Indicate a missing piece of documentation
+title: ''
+labels: Documentation
+assignees: ''
+
+---
+
+**To what scenario is your documentation request related? Please describe.**
+A clear and concise description of what the scenario is. I'm trying to [...] but can not find adequate documentation.
+
+**Additional context**
+Add any other context or screenshots about the documentation request here.

--- a/core/java/iesi-core/pom.xml
+++ b/core/java/iesi-core/pom.xml
@@ -291,6 +291,12 @@
             <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.16.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
@@ -51,7 +51,7 @@ public class DataInstructionRepository {
         BelgiumNationalRegisterNumber belgiumNationalRegisterNumber = new BelgiumNationalRegisterNumber();
         dataInstructions.put(belgiumNationalRegisterNumber.getKeyword(), belgiumNationalRegisterNumber);
 
-        NumberBetween numberBetween = new NumberBetween(generationObjectExecution);
+        NumberBetween numberBetween = new NumberBetween();
         dataInstructions.put(numberBetween.getKeyword(), numberBetween);
 
         TextSubstring textSubstring = new TextSubstring();

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -39,7 +39,7 @@ public class NumberBetween implements DataInstruction {
         double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
         double generatedNumber = range(lowerBound, upperBound);
 
-        if (Objects.isNull(strNumberOfDecimals))
+        if (strNumberOfDecimals == null)
             return Double.toString(generatedNumber);
 
         if (Pattern.compile("\\.").matcher(strNumberOfDecimals).find())
@@ -50,8 +50,8 @@ public class NumberBetween implements DataInstruction {
         if (numberOfDecimals < 0)
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
 
-        DecimalFormat decimalFormatter = getADecimalFormatter(numberOfDecimals);
-        return decimalFormatter.format(generatedNumber);
+        return getADecimalFormatter(numberOfDecimals)
+                .format(generatedNumber);
 
     }
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -1,43 +1,93 @@
 package io.metadew.iesi.script.execution.instruction.data.number;
 
-import io.metadew.iesi.data.generation.execution.GenerationObjectExecution;
 import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 
+import java.math.RoundingMode;
+import java.security.SecureRandom;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * @author peter.billen
- */
 public class NumberBetween implements DataInstruction {
     private final String LOWER_BOUND_KEY = "LowerBoundRepresentation";
-
     private final String UPPER_BOUND_KEY = "UpperBoundRepresentation";
+    private final String NUMBER_OF_DECIMALS = "NumberOfDecimalRepresentation";
+    private final SecureRandom secureRandom;
+
+    public NumberBetween() {
+        secureRandom = new SecureRandom();
+    }
 
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern
-            .compile("\\s*\"?(?<" + LOWER_BOUND_KEY + ">\\d+)\"?\\s*,\\s*\"?(?<" + UPPER_BOUND_KEY + ">\\d+)\"?\\s*");
-
-    private final GenerationObjectExecution generationObjectExecution;
-
-    public NumberBetween(GenerationObjectExecution generationObjectExecution) {
-        this.generationObjectExecution = generationObjectExecution;
-    }
+            .compile("^\\s*\"?\\s*(?<" + LOWER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*," +
+                    "\\s*\"?\\s*(?<" + UPPER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*" +
+                    "(?:,\\s*\"?\\s*(?<" + NUMBER_OF_DECIMALS + ">-?\\d*(?:\\.\\d+)?)\\s*\"?\\s*)?");
 
     @Override
     public String generateOutput(String parameters) {
         Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
-        if (!inputParameterMatcher.find()) {
+
+        if (!inputParameterMatcher.find())
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
-        } else {
-            double lowerBound = Double.parseDouble(inputParameterMatcher.group(LOWER_BOUND_KEY));
-            double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
-            return Double.toString(generationObjectExecution.getNumber().between(lowerBound, upperBound));
-        }
+
+        String strNumberOfDecimals = inputParameterMatcher.group(NUMBER_OF_DECIMALS);
+
+        double lowerBound = Double.parseDouble(inputParameterMatcher.group(LOWER_BOUND_KEY));
+        double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
+        double generatedNumber = range(lowerBound, upperBound);
+
+        if (Objects.isNull(strNumberOfDecimals))
+            return Double.toString(generatedNumber);
+
+        if (Pattern.compile("\\.").matcher(strNumberOfDecimals).find())
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+
+        int numberOfDecimals = Integer.parseInt(strNumberOfDecimals);
+
+        if (numberOfDecimals < 0)
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+
+        DecimalFormat decimalFormatter = getADecimalFormatter(numberOfDecimals);
+        return decimalFormatter.format(generatedNumber);
+
     }
 
     @Override
     public String getKeyword() {
         return "number.between";
+    }
+
+    /**
+     * @param numberOfDecimal int, it is the number of decimal the formatter will be configured for
+     * @return an instance of DecimalFormat configured with RoundingMode.HALF_EVEN and groupUse to false
+     */
+    private DecimalFormat getADecimalFormatter(int numberOfDecimal) {
+        DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+        decimalFormatSymbols.setDecimalSeparator('.');
+        DecimalFormat decimalFormatter = new DecimalFormat("#", decimalFormatSymbols);
+        decimalFormatter.setMinimumIntegerDigits(1);
+        decimalFormatter.setMaximumFractionDigits(numberOfDecimal);
+        decimalFormatter.setMinimumFractionDigits(numberOfDecimal);
+        decimalFormatter.setRoundingMode(RoundingMode.HALF_EVEN);
+        decimalFormatter.setGroupingUsed(false);
+        return decimalFormatter;
+    }
+
+
+    /**
+     * @param min double
+     * @param max double
+     * @return a secure random number between min and max parameter
+     */
+    private double range(double min, double max) {
+        if (max < min) {
+            double temp = max;
+            max = min;
+            min = temp;
+        }
+        return secureRandom.nextDouble() * (max - min) + min;
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -38,8 +38,6 @@ public class NumberBetween implements DataInstruction {
 
         String strNumberOfDecimals = inputParameterMatcher.group(NUMBER_OF_DECIMALS);
 
-        System.out.println(strNumberOfDecimals);
-
         double lowerBound = Double.parseDouble(inputParameterMatcher.group(LOWER_BOUND_KEY));
         double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
         double generatedNumber = range(lowerBound, upperBound);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -7,7 +7,6 @@ import java.security.SecureRandom;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -21,7 +21,7 @@ public class NumberBetween implements DataInstruction {
     }
 
     // Regex : g1, g2 and g3 are the capturing group
-    // ^\s*\"?\s*(?<g1>-?\d+(?:\.\d+)?)\s*\"?\s*,\s*\"?\s*(?<g2>-?\d+(?:\.\d+)?)\s*\"?\s*(?:,\s*\"?\s*(?<g3>\D*-?\d*(?:\.\d+)?\D*?)\s*\"?\s*)?
+    // ^\s*\"?\s*(?<g1>-?\d+(?:\.\d+)?)\s*\"?\s*,\s*\"?\s*(?<g2>-?\d+(?:\.\d+)?)\s*\"?\s*(?:,\s*\"?\s*(?<g3>\D*-?\d*(?:\.\d+)?\D*?)\s*\"?\s*)?$
     // As g3 is an optional group, the regex can't fail its match because of a bad input in g3 so we allowed
     // and capture all the possible input and test it on line 51
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -20,6 +20,10 @@ public class NumberBetween implements DataInstruction {
         secureRandom = new SecureRandom();
     }
 
+    // Regex : g1, g2 and g3 are the capturing group
+    // ^\s*\"?\s*(?<g1>-?\d+(?:\.\d+)?)\s*\"?\s*,\s*\"?\s*(?<g2>-?\d+(?:\.\d+)?)\s*\"?\s*(?:,\s*\"?\s*(?<g3>-?\d*(?:\.\d+)?)\s*\"?\s*)?
+    // As g3 is an optional group, the regex can't fail its match because of a bad input in g3 so we allowed the dot
+    // to capture an eventual float number and throw an error later if a dot is present
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern
             .compile("^\\s*\"?\\s*(?<" + LOWER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*," +
                     "\\s*\"?\\s*(?<" + UPPER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*" +
@@ -41,6 +45,7 @@ public class NumberBetween implements DataInstruction {
         if (strNumberOfDecimals == null)
             return Double.toString(generatedNumber);
 
+        // See line 25
         if (Pattern.compile("\\.").matcher(strNumberOfDecimals).find())
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -21,13 +21,13 @@ public class NumberBetween implements DataInstruction {
     }
 
     // Regex : g1, g2 and g3 are the capturing group
-    // ^\s*\"?\s*(?<g1>-?\d+(?:\.\d+)?)\s*\"?\s*,\s*\"?\s*(?<g2>-?\d+(?:\.\d+)?)\s*\"?\s*(?:,\s*\"?\s*(?<g3>-?\d*(?:\.\d+)?)\s*\"?\s*)?
-    // As g3 is an optional group, the regex can't fail its match because of a bad input in g3 so we allowed the dot
-    // to capture an eventual float number and throw an error later if a dot is present
+    // ^\s*\"?\s*(?<g1>-?\d+(?:\.\d+)?)\s*\"?\s*,\s*\"?\s*(?<g2>-?\d+(?:\.\d+)?)\s*\"?\s*(?:,\s*\"?\s*(?<g3>\D*-?\d*(?:\.\d+)?\D*?)\s*\"?\s*)?
+    // As g3 is an optional group, the regex can't fail its match because of a bad input in g3 so we allowed
+    // and capture all the possible input and test it on line 51
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern
             .compile("^\\s*\"?\\s*(?<" + LOWER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*," +
                     "\\s*\"?\\s*(?<" + UPPER_BOUND_KEY + ">-?\\d+(?:\\.\\d+)?)\\s*\"?\\s*" +
-                    "(?:,\\s*\"?\\s*(?<" + NUMBER_OF_DECIMALS + ">-?\\d*(?:\\.\\d+)?)\\s*\"?\\s*)?");
+                    "(?:,\\s*\"?\\s*(?<" + NUMBER_OF_DECIMALS + ">\\D*-?\\d*(?:\\.\\d+)?\\D*?)\\s*\"?\\s*)?$");
 
     @Override
     public String generateOutput(String parameters) {
@@ -38,6 +38,8 @@ public class NumberBetween implements DataInstruction {
 
         String strNumberOfDecimals = inputParameterMatcher.group(NUMBER_OF_DECIMALS);
 
+        System.out.println(strNumberOfDecimals);
+
         double lowerBound = Double.parseDouble(inputParameterMatcher.group(LOWER_BOUND_KEY));
         double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
         double generatedNumber = range(lowerBound, upperBound);
@@ -46,7 +48,7 @@ public class NumberBetween implements DataInstruction {
             return Double.toString(generatedNumber);
 
         // See line 25
-        if (Pattern.compile("\\.").matcher(strNumberOfDecimals).find())
+        if (!Pattern.compile("^\\d+$").matcher(strNumberOfDecimals).find())
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
 
         int numberOfDecimals = Integer.parseInt(strNumberOfDecimals);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetween.java
@@ -42,12 +42,9 @@ public class NumberBetween implements DataInstruction {
         double upperBound = Double.parseDouble(inputParameterMatcher.group(UPPER_BOUND_KEY));
         double generatedNumber = range(lowerBound, upperBound);
 
+        // no 3rd arg provided
         if (strNumberOfDecimals == null)
             return Double.toString(generatedNumber);
-
-        // See line 25
-        if (!Pattern.compile("^\\d+$").matcher(strNumberOfDecimals).find())
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
 
         int numberOfDecimals = Integer.parseInt(strNumberOfDecimals);
 

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -1,0 +1,55 @@
+package io.metadew.iesi.script.execution.instruction.data.number;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NumberBetweenTest {
+
+    NumberBetween numberBetween = new NumberBetween();
+
+    @Test
+    void illegalInput() {
+        assertAll(()->{
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(""), "parameters : \"\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, 5"), "parameters: \" Illegal, 5\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5, Illegal"), "parameters: \" 5, Illegal\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, Illegal"), "parameters: \" Illegal, Illegal\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, 5, 32"), "parameters: \" Illegal, 5, 32\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 2  , 5 , -1"), "parameters: \" 2  , 5 , -1\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput("   , 5 , 1"), "parameters: \"   , 5 , 1\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5  ,  , 1"), "parameters: \" 5  ,  , 1\"");
+            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5  , 2 ,  "),"parameters: \" 5  , 2 ,  \"");
+        });
+    }
+
+    @Test
+    void shortNumberFormatTests() {
+        assertAll(()->{
+            assertEquals("2", numberBetween.generateOutput("2,2,0"),"parameters: 2,2,0");
+            assertEquals("2.0", numberBetween.generateOutput("2,2,1"),"parameters: 2,2,1");
+            assertEquals("2.0", numberBetween.generateOutput("2,2"),"parameters: 2,2");
+            assertEquals("2.00", numberBetween.generateOutput("2,2,2"),"parameters: 2,2,2");
+            assertEquals("2.000", numberBetween.generateOutput("2,2,3"),"parameters: 2,2,3");
+            assertEquals("2.0000000000", numberBetween.generateOutput("2,2,10"),"parameters: 2,2,10");
+        });
+    }
+
+    @Test
+    void biggerNumberFormatTest(){
+        assertEquals("2000.0" , numberBetween.generateOutput("2000,2000"), "parameter: 2000,2000");
+        assertEquals("2000" , numberBetween.generateOutput("2000,2000,0"), "parameter: 2000,2000,0");
+        assertEquals("2000.0" , numberBetween.generateOutput("2000,2000,1"), "parameter: 2000,2000,1");
+        assertEquals("2000.00" , numberBetween.generateOutput("2000,2000,2"), "parameter: 2000,2000,2");
+    }
+
+    @Test
+    void floatNumberFormatTest(){
+        assertEquals("1999.99",numberBetween.generateOutput("1999.99,1999.99,2"));
+        assertEquals("1999.99879",numberBetween.generateOutput("1999.99879,1999.99879,5"));
+        assertEquals("2000.00",numberBetween.generateOutput("1999.99879,1999.99879,2"));
+    }
+
+
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -1,53 +1,297 @@
 package io.metadew.iesi.script.execution.instruction.data.number;
 
+import io.metadew.iesi.datatypes.array.Array;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class NumberBetweenTest {
 
     NumberBetween numberBetween = new NumberBetween();
 
     @Test
-    void illegalInput() {
-        assertAll(()->{
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(""), "parameters : \"\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, 5"), "parameters: \" Illegal, 5\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5, Illegal"), "parameters: \" 5, Illegal\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, Illegal"), "parameters: \" Illegal, Illegal\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" Illegal, 5, 32"), "parameters: \" Illegal, 5, 32\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 2  , 5 , -1"), "parameters: \" 2  , 5 , -1\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput("   , 5 , 1"), "parameters: \"   , 5 , 1\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5  ,  , 1"), "parameters: \" 5  ,  , 1\"");
-            assertThrows(IllegalArgumentException.class, () -> numberBetween.generateOutput(" 5  , 2 ,  "),"parameters: \" 5  , 2 ,  \"");
-        });
+    void illegalInputTest() {
+
+        assertThatIllegalArgumentException()
+                .as("empty parameters should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(""));
+
+        assertThatIllegalArgumentException()
+                .as("Illegal first argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5"));
+
+        assertThatIllegalArgumentException()
+                .as("Illegal second argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 5, Illegal"));
+
+        assertThatIllegalArgumentException()
+                .as("2 illegals arguments should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, Illegal"));
+
+        assertThatIllegalArgumentException()
+                .as("Illegal first argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5, 32"));
+
+        assertThatIllegalArgumentException()
+                .as("Negative 3rd argument is Illegal and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 2  , 5 , -1"));
+
+        assertThatIllegalArgumentException()
+                .as("Empty first argument is Illegal and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput("   , 5 , 1"));
+
+        assertThatIllegalArgumentException()
+                .as("Empty second argument is Illegal and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 5  ,  , 1"));
+
+        assertThatIllegalArgumentException()
+                .as("Optional parameter initiated and left empty is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 5  , 2 ,  "));
+
+        assertThatIllegalArgumentException()
+                .as("3rd argument as a float is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , 2.0 "));
+
+        assertThatIllegalArgumentException()
+                .as("3rd argument as a float is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , 3.58 "));
+
+        assertThatIllegalArgumentException()
+                .as("\"--\" is illegal an should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" --1  , 2"));
+
+        assertThatIllegalArgumentException()
+                .as("\"--\" is illegal an should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , --2"));
+
     }
 
     @Test
-    void shortNumberFormatTests() {
-        assertAll(()->{
-            assertEquals("2", numberBetween.generateOutput("2,2,0"),"parameters: 2,2,0");
-            assertEquals("2.0", numberBetween.generateOutput("2,2,1"),"parameters: 2,2,1");
-            assertEquals("2.0", numberBetween.generateOutput("2,2"),"parameters: 2,2");
-            assertEquals("2.00", numberBetween.generateOutput("2,2,2"),"parameters: 2,2,2");
-            assertEquals("2.000", numberBetween.generateOutput("2,2,3"),"parameters: 2,2,3");
-            assertEquals("2.0000000000", numberBetween.generateOutput("2,2,10"),"parameters: 2,2,10");
-        });
+    void shortNumberFormatTest() {
+        assertThat(numberBetween.generateOutput("2,2"))
+                .as("parameters: 2,2")
+                .isEqualTo("2.0");
+
+        assertThat(numberBetween.generateOutput("2,2,0"))
+                .as("parameters: 2,2,0")
+                .isEqualTo("2");
+
+        assertThat(numberBetween.generateOutput("2,2,1"))
+                .as("parameters: 2,2,1")
+                .isEqualTo("2.0");
+
+        assertThat(numberBetween.generateOutput("2,2,2"))
+                .as("parameters: 2,2,2")
+                .isEqualTo("2.00");
+
+        assertThat(numberBetween.generateOutput("2,2,3"))
+                .as("parameters: 2,2,3")
+                .isEqualTo("2.000");
+
+        assertThat(numberBetween.generateOutput("2,2,10"))
+                .as("parameters: 2,2,1")
+                .isEqualTo("2.0000000000");
+
     }
 
     @Test
-    void biggerNumberFormatTest(){
-        assertEquals("2000.0" , numberBetween.generateOutput("2000,2000"), "parameter: 2000,2000");
-        assertEquals("2000" , numberBetween.generateOutput("2000,2000,0"), "parameter: 2000,2000,0");
-        assertEquals("2000.0" , numberBetween.generateOutput("2000,2000,1"), "parameter: 2000,2000,1");
-        assertEquals("2000.00" , numberBetween.generateOutput("2000,2000,2"), "parameter: 2000,2000,2");
+    void shortNegativeNumberFormatTest() {
+        assertThat(numberBetween.generateOutput("-2,-2"))
+                .as("parameters: -2,-2")
+                .isEqualTo("-2.0");
+
+        assertThat(numberBetween.generateOutput("-2,-2,0"))
+                .as("parameters: -2,-2,0")
+                .isEqualTo("-2");
+
+        assertThat(numberBetween.generateOutput("-2,-2,1"))
+                .as("parameters: -2,-2,1")
+                .isEqualTo("-2.0");
+
+        assertThat(numberBetween.generateOutput("-2,-2,2"))
+                .as("parameters: -2,-2,2")
+                .isEqualTo("-2.00");
+
+        assertThat(numberBetween.generateOutput("-2,-2,3"))
+                .as("parameters: -2,-2,3")
+                .isEqualTo("-2.000");
+
+        assertThat(numberBetween.generateOutput("-2,-2,10"))
+                .as("parameters: -2,-2,1")
+                .isEqualTo("-2.0000000000");
+
     }
 
     @Test
-    void floatNumberFormatTest(){
-        assertEquals("1999.99",numberBetween.generateOutput("1999.99,1999.99,2"));
-        assertEquals("1999.99879",numberBetween.generateOutput("1999.99879,1999.99879,5"));
-        assertEquals("2000.00",numberBetween.generateOutput("1999.99879,1999.99879,2"));
+    void biggerNumberFormatTest() {
+        assertThat(numberBetween.generateOutput("200000,200000"))
+                .as("parameter: 200000,200000")
+                .isEqualTo("200000.0");
+
+        assertThat(numberBetween.generateOutput("200000,200000,0"))
+                .as("parameter: 200000,200000,0")
+                .isEqualTo("200000");
+
+        assertThat(numberBetween.generateOutput("200000,200000,1"))
+                .as("parameter: 200000,200000,1")
+                .isEqualTo("200000.0");
+
+        assertThat(numberBetween.generateOutput("200000,200000,2"))
+                .as("parameter: 200000,200000,2")
+                .isEqualTo("200000.00");
+
+        assertThat(numberBetween.generateOutput("200000,200000,3"))
+                .as("parameter: 200000,200000,2")
+                .isEqualTo("200000.000");
+
+        assertThat(numberBetween.generateOutput("200000,200000,4"))
+                .as("parameter: 200000,200000,2")
+                .isEqualTo("200000.0000");
+
+        assertThat(numberBetween.generateOutput("200000,200000,5"))
+                .as("parameter: 200000,200000,2")
+                .isEqualTo("200000.00000");
+
+    }
+
+    @Test
+    void floatNumberFormatTest() {
+        assertThat(numberBetween.generateOutput("1999.99,1999.99,2"))
+                .isEqualTo("1999.99");
+
+        assertThat(numberBetween.generateOutput("1999.99879,1999.99879,5"))
+                .isEqualTo("1999.99879");
+
+        assertThat(numberBetween.generateOutput("1999.99879,1999.99879,2"))
+                .isEqualTo("2000.00");
+
+    }
+
+    @Test
+    void outputRangeTest2args() {
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0, 10")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 100.0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 100.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10000.0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10000.0);
+
+    }
+
+    @Test
+    void outputRangeTest3rdArgs() {
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0, 1000, 0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0, 10, 0")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0, 1")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 1")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0, 2")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 2")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0, 3")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 3")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0, 4")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 4")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 1000.0, 5")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 1000.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 5")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+    }
+
+    @Test
+    void negativeNumberTest() {
+        assertThat(Double.parseDouble(numberBetween.generateOutput("-10, -1")))
+                .isNotNull()
+                .isNegative()
+                .isBetween(-10.00, -1.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("-10, -1, 0")))
+                .isNotNull()
+                .isNegative()
+                .isBetween(-10.00, -1.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("-10, -1, 1")))
+                .isNotNull()
+                .isNegative()
+                .isBetween(-10.00, -1.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("-10, -1, 2")))
+                .isNotNull()
+                .isNegative()
+                .isBetween(-10.00, -1.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("-10, -1, 3")))
+                .isNotNull()
+                .isNegative()
+                .isBetween(-10.00, -1.0);
+
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -1,13 +1,9 @@
 package io.metadew.iesi.script.execution.instruction.data.number;
 
-import io.metadew.iesi.datatypes.array.Array;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class NumberBetweenTest {
 

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -10,43 +10,89 @@ public class NumberBetweenTest {
     NumberBetween numberBetween = new NumberBetween();
 
     @Test
-    void illegalInputTest() {
+    void illegalInputGeneralTest() {
 
         assertThatIllegalArgumentException()
                 .as("empty parameters should throw an IllegalArgumentException")
                 .isThrownBy(() -> numberBetween.generateOutput(""));
 
         assertThatIllegalArgumentException()
-                .as("Illegal first argument should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5"));
+                .as("empty parameters should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" , "));
 
         assertThatIllegalArgumentException()
-                .as("Illegal second argument should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" 5, Illegal"));
+                .as("empty parameters should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" , , "));
+
+        assertThatIllegalArgumentException()
+                .as("Illegal argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal "));
 
         assertThatIllegalArgumentException()
                 .as("2 illegals arguments should throw an IllegalArgumentException")
                 .isThrownBy(() -> numberBetween.generateOutput(" Illegal, Illegal"));
 
         assertThatIllegalArgumentException()
+                .as("3 illegals arguments should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, Illegal, Illegal"));
+
+    }
+
+    @Test
+    void illegalInput1stArgTest() {
+        assertThatIllegalArgumentException()
                 .as("Illegal first argument should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5, 32"));
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5"));
 
         assertThatIllegalArgumentException()
-                .as("Negative 3rd argument is Illegal and should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" 2  , 5 , -1"));
+                .as("Illegal first argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" Illegal, 5, 32"));
 
         assertThatIllegalArgumentException()
                 .as("Empty first argument is Illegal and should throw an IllegalArgumentException")
                 .isThrownBy(() -> numberBetween.generateOutput("   , 5 , 1"));
 
         assertThatIllegalArgumentException()
+                .as("\"--\" is illegal an should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" --1  , 2"));
+
+        assertThatIllegalArgumentException()
+                .as("lol")
+                .isThrownBy(()->numberBetween.generateOutput(" \"2Illegal\"  , \"2\" , \"2\""));
+    }
+
+    @Test
+    void illegalInput2ndArgTest() {
+        assertThatIllegalArgumentException()
+                .as("Illegal second argument should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 5, Illegal"));
+
+        assertThatIllegalArgumentException()
+                .as("Empty second argument is Illegal and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 5, "));
+
+        assertThatIllegalArgumentException()
                 .as("Empty second argument is Illegal and should throw an IllegalArgumentException")
                 .isThrownBy(() -> numberBetween.generateOutput(" 5  ,  , 1"));
 
         assertThatIllegalArgumentException()
-                .as("Optional parameter initiated and left empty is an illegal argument and should throw an IllegalArgumentException")
+                .as("\"--\" is illegal an should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , --2"));
+
+        assertThatIllegalArgumentException()
+                .as("lol")
+                .isThrownBy(()->numberBetween.generateOutput(" \"2\"  , \"2Illegal\" , \"2\""));
+    }
+
+    @Test
+    void illegalInput3rdArgTest() {
+        assertThatIllegalArgumentException()
+                .as("Optional 3rd argument initiated and left empty is an illegal argument and should throw an IllegalArgumentException")
                 .isThrownBy(() -> numberBetween.generateOutput(" 5  , 2 ,  "));
+
+        assertThatIllegalArgumentException()
+                .as("Negative 3rd argument is Illegal and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 2  , 5 , -1"));
 
         assertThatIllegalArgumentException()
                 .as("3rd argument as a float is an illegal argument and should throw an IllegalArgumentException")
@@ -57,12 +103,40 @@ public class NumberBetweenTest {
                 .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , 3.58 "));
 
         assertThatIllegalArgumentException()
-                .as("\"--\" is illegal an should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" --1  , 2"));
+                .as("3rd argument as a string is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , Illegal "));
 
         assertThatIllegalArgumentException()
-                .as("\"--\" is illegal an should throw an IllegalArgumentException")
-                .isThrownBy(() -> numberBetween.generateOutput(" 1  , --2"));
+                .as("3rd argument as a string is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , Illegal.Illegal "));
+
+        assertThatIllegalArgumentException()
+                .as("3rd argument contain string. It is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , 2.Illegal "));
+
+        assertThatIllegalArgumentException()
+                .as("3rd argument contain string. It is an illegal argument and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , Illegal.2 "));
+
+        assertThatIllegalArgumentException()
+                .as("3rd argument is not properly formatted and should throw an IllegalArgumentException")
+                .isThrownBy(() -> numberBetween.generateOutput(" 1  , 2 , 2,0 "));
+
+        assertThatIllegalArgumentException()
+                .as("lol")
+                .isThrownBy(()->numberBetween.generateOutput(" \"2\"  , \"2\" , \"2Illegal\""));
+
+    }
+
+    @Test
+    void originalAllowedInput() {
+        assertThat(numberBetween.generateOutput(" \"2\"  , \"2\" , \"2\""))
+                .as("parameters <\"2\"  , \"2\" , \"2\"> should be allowed")
+                .isEqualTo("2.00");
+
+        assertThat(numberBetween.generateOutput(" \"2\"  , \"2\" , \"2\""))
+                .as("parameters <\"20\"  , \"20\" , \"20\"> should be allowed")
+                .isEqualTo("2.00");
 
     }
 
@@ -194,6 +268,11 @@ public class NumberBetweenTest {
                 .isNotNegative()
                 .isBetween(0.0, 10000.0);
 
+        assertThat(Double.parseDouble(numberBetween.generateOutput("\"0.0\", \"10000.0\"")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10000.0);
+
     }
 
     @Test
@@ -255,6 +334,11 @@ public class NumberBetweenTest {
                 .isBetween(0.0, 1000.0);
 
         assertThat(Double.parseDouble(numberBetween.generateOutput("0.0, 10.0, 5")))
+                .isNotNull()
+                .isNotNegative()
+                .isBetween(0.0, 10.0);
+
+        assertThat(Double.parseDouble(numberBetween.generateOutput("\"0.0\", \"10.0\", \"5\"")))
                 .isNotNull()
                 .isNotNegative()
                 .isBetween(0.0, 10.0);

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -50,6 +50,4 @@ public class NumberBetweenTest {
         assertEquals("2000.00",numberBetween.generateOutput("1999.99879,1999.99879,2"));
     }
 
-
-
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberBetweenTest.java
@@ -58,7 +58,8 @@ public class NumberBetweenTest {
 
         assertThatIllegalArgumentException()
                 .as("lol")
-                .isThrownBy(()->numberBetween.generateOutput(" \"2Illegal\"  , \"2\" , \"2\""));
+                .isThrownBy(() -> numberBetween.generateOutput(" \"2Illegal\"  , \"2\" , \"2\""));
+
     }
 
     @Test
@@ -81,7 +82,8 @@ public class NumberBetweenTest {
 
         assertThatIllegalArgumentException()
                 .as("lol")
-                .isThrownBy(()->numberBetween.generateOutput(" \"2\"  , \"2Illegal\" , \"2\""));
+                .isThrownBy(() -> numberBetween.generateOutput(" \"2\"  , \"2Illegal\" , \"2\""));
+
     }
 
     @Test
@@ -124,7 +126,7 @@ public class NumberBetweenTest {
 
         assertThatIllegalArgumentException()
                 .as("lol")
-                .isThrownBy(()->numberBetween.generateOutput(" \"2\"  , \"2\" , \"2Illegal\""));
+                .isThrownBy(() -> numberBetween.generateOutput(" \"2\"  , \"2\" , \"2Illegal\""));
 
     }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently the {{*number.between()}} function returns a decimal value ex:
result=resolved {{*number.between("1","120")}} to 32.596405830858956
Unfortunately this can not be used in cases where an integer (whole number) is expected.

**Describe the solution you'd like**
Additional function parameter that would specify amount of decimals (ex: 0 = whole number,...)

**Id**
71f29e3
