### PR TITLE
Standardize endpoint naming convention

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/actiontypes/ActionTypeController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/actiontypes/ActionTypeController.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 @RestController
 @CrossOrigin
 @Tag(name = "actionTypes", description = "Everything about action types")
-@RequestMapping("/action_types")
+@RequestMapping("/action-types")
 public class ActionTypeController {
 
     private IActionTypeDtoService actionTypeDtoService;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connectiontypes/ConnectionTypeController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connectiontypes/ConnectionTypeController.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @Tag(name = "connectionTypes", description = "Everything about connection types")
-@RequestMapping("/connection_types")
+@RequestMapping("/connection-types")
 @CrossOrigin
 public class ConnectionTypeController {
 

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/executionrequest/ExecutionRequestController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/executionrequest/ExecutionRequestController.java
@@ -27,7 +27,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RestController
 @CrossOrigin
 @Tag(name = "execution requests", description = "Everything about execution requests")
-@RequestMapping("/execution_requests")
+@RequestMapping("/execution-requests")
 public class ExecutionRequestController {
 
     private final ExecutionRequestDtoResourceAssembler executionRequestDtoResourceAssembler;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/result/ScriptResultController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/result/ScriptResultController.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @Tag(name = "scriptResults", description = "Everything about scriptResults")
-@RequestMapping("/script_results")
+@RequestMapping("/script-results")
 @CrossOrigin
 public class ScriptResultController {
     private final IScriptResultService scriptResultService;


### PR DESCRIPTION
**Describe the bug**
At the moment, a mix of the camel case, hyphen and underscore naming conventions is used for the REST endpoints. This should be standardized to one naming convention.

As a naming convention we propose to use hyphens to separate words in an url.

**id**: a26ac18