### PR TITLE
Allow fetch element from list with list reference name 

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ExecutionRuntime.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/ExecutionRuntime.java
@@ -531,11 +531,11 @@ public class ExecutionRuntime {
         return Optional.ofNullable(datasetMap.get(referenceName));
     }
 
-    public void setArray(String referenceName, Array array) throws IOException {
+    public void setArray(String referenceName, Array array) {
         arrayMap.put(referenceName, array);
     }
 
-    public Optional<Array> getArray(String referenceName) throws IOException {
+    public Optional<Array> getArray(String referenceName) {
         return Optional.ofNullable(arrayMap.get(referenceName));
     }
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/lookup/ListLookup.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/lookup/ListLookup.java
@@ -43,7 +43,7 @@ public class ListLookup implements LookupInstruction {
         Array array = getArray(DataTypeHandler.getInstance().resolve(arguments[0], executionRuntime));
         DataType elementSelector = DataTypeHandler.getInstance().resolve(arguments[1], executionRuntime);
         if (elementSelector instanceof Text) {
-            int index = Integer.parseInt(((Text) elementSelector).getString()) - 1;
+            int index = Integer.parseInt(((Text) elementSelector).getString().trim()) - 1;
             return array.getList().get(index).toString();
         } else if (elementSelector instanceof Template) {
             for (DataType dataType : array.getList()) {
@@ -68,6 +68,9 @@ public class ListLookup implements LookupInstruction {
     private Array getArray(DataType array) {
         if (array instanceof Array) {
             return (Array) array;
+        } else if (array instanceof Text) {
+            return executionRuntime.getArray(((Text) array).getString())
+                    .orElseThrow(() -> new IllegalArgumentException(MessageFormat.format("No array found with reference name {0}", ((Text) array).getString())));
         } else {
             throw new IllegalArgumentException(MessageFormat.format("list cannot be of type {0}", array.getClass()));
         }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
when executing the instruction {{=list(\<list\>, \<element\>}}, I want to be able to define \<list\> as a string referencing a previously stored array.

**Id**
cb705b3