### PR TITLE
Handle non-established connection 

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
@@ -66,10 +66,20 @@ public class SqlEvaluateResult extends ActionTypeExecution {
         boolean hasResult = convertHasResult(getExpectedResult().getValue());
         String connectionName = convertConnectionName(getConnectionName().getValue());
 
-        Connection connection = ConnectionConfiguration.getInstance()
-                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .get();
+        Connection connection;
+        try {
+            connection = ConnectionConfiguration.getInstance()
+                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                    .get();
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown connection name");
+        }
+
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
+        if (database == null) {
+            throw new RuntimeException("Error establishing DB connection");
+        }
+
         // Run the action
         CachedRowSet crs;
         crs = DatabaseHandler.getInstance().executeQueryLimitRows(database, query, 10);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
@@ -67,18 +67,11 @@ public class SqlEvaluateResult extends ActionTypeExecution {
         String connectionName = convertConnectionName(getConnectionName().getValue());
 
         Connection connection;
-        try {
-            connection = ConnectionConfiguration.getInstance()
-                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                    .get();
-        } catch (Exception e) {
-            throw new RuntimeException("Unknown connection name");
-        }
+        connection = ConnectionConfiguration.getInstance()
+                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
-        if (database == null) {
-            throw new RuntimeException("Error establishing DB connection");
-        }
 
         // Run the action
         CachedRowSet crs;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlEvaluateResult.java
@@ -66,10 +66,9 @@ public class SqlEvaluateResult extends ActionTypeExecution {
         boolean hasResult = convertHasResult(getExpectedResult().getValue());
         String connectionName = convertConnectionName(getConnectionName().getValue());
 
-        Connection connection;
-        connection = ConnectionConfiguration.getInstance()
+        Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
+                .orElseThrow(() -> new RuntimeException("Unknown connection name: " + connectionName));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
@@ -86,10 +86,9 @@ public class SqlExecuteProcedure extends ActionTypeExecution {
         boolean appendOutput = convertAppendOutput(getSqlProcedure().getValue());
 
         // Get Connection
-        Connection connection;
-        connection = ConnectionConfiguration.getInstance()
+        Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
+                .orElseThrow(() -> new RuntimeException("Unknown connection name: " + connectionName));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
@@ -87,18 +87,11 @@ public class SqlExecuteProcedure extends ActionTypeExecution {
 
         // Get Connection
         Connection connection;
-        try {
-            connection = ConnectionConfiguration.getInstance()
-                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                    .get();
-        } catch (Exception e) {
-            throw new RuntimeException("Unknown connection name");
-        }
+        connection = ConnectionConfiguration.getInstance()
+                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
-        if (database == null) {
-            throw new RuntimeException("Error establishing DB connection");
-        }
 
         SqlScriptResult sqlScriptResult = null;
         CachedRowSet crs = null;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteProcedure.java
@@ -86,9 +86,14 @@ public class SqlExecuteProcedure extends ActionTypeExecution {
         boolean appendOutput = convertAppendOutput(getSqlProcedure().getValue());
 
         // Get Connection
-        Connection connection = ConnectionConfiguration.getInstance()
-                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .get();
+        Connection connection;
+        try {
+            connection = ConnectionConfiguration.getInstance()
+                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                    .get();
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown connection name");
+        }
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
         if (database == null) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
@@ -118,18 +118,11 @@ public class SqlExecuteQuery extends ActionTypeExecution {
         boolean appendOutput = convertAppendOutput(getConnectionName().getValue());
         // Get Connection
         Connection connection;
-        try {
-            connection = ConnectionConfiguration.getInstance()
-                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                    .get();
-        } catch (Exception e) {
-            throw new RuntimeException("Unknown connection name");
-        }
+        connection = ConnectionConfiguration.getInstance()
+                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
-        if (database == null) {
-            throw new RuntimeException("Error establishing DB connection");
-        }
 
         // Run the action
         // Make sure the SQL statement is ended with a ;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
@@ -117,9 +117,14 @@ public class SqlExecuteQuery extends ActionTypeExecution {
         String outputDatasetReferenceName = convertDatasetReferenceName(getSqlQuery().getValue());
         boolean appendOutput = convertAppendOutput(getConnectionName().getValue());
         // Get Connection
-        Connection connection = ConnectionConfiguration.getInstance()
-                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .get();
+        Connection connection;
+        try {
+            connection = ConnectionConfiguration.getInstance()
+                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                    .get();
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown connection name");
+        }
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
         if (database == null) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
@@ -117,10 +117,9 @@ public class SqlExecuteQuery extends ActionTypeExecution {
         String outputDatasetReferenceName = convertDatasetReferenceName(getSqlQuery().getValue());
         boolean appendOutput = convertAppendOutput(getConnectionName().getValue());
         // Get Connection
-        Connection connection;
-        connection = ConnectionConfiguration.getInstance()
+        Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
+                .orElseThrow(() -> new RuntimeException("Unknown connection name: " + connectionName));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
@@ -55,8 +55,14 @@ public class SqlExecuteStatement extends ActionTypeExecution {
         String sqlStatement = convertSqlStatement(getSqlStatement().getValue());
         String connectionName = convertConnectionName(getConnectionName().getValue());
         // Get Connection
-        Connection connection = ConnectionConfiguration.getInstance().get(new ConnectionKey(connectionName, getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Cannot find connection " + connectionName));
+        Connection connection;
+        try {
+            connection = ConnectionConfiguration.getInstance().get(new ConnectionKey(connectionName, getExecutionControl().getEnvName()))
+                    .orElseThrow(() -> new RuntimeException("Cannot find connection " + connectionName));
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown connection name");
+        }
+
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
         if (database == null) {
             throw new RuntimeException("Error establishing DB connection");

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
@@ -55,10 +55,9 @@ public class SqlExecuteStatement extends ActionTypeExecution {
         String sqlStatement = convertSqlStatement(getSqlStatement().getValue());
         String connectionName = convertConnectionName(getConnectionName().getValue());
         // Get Connection
-        Connection connection;
-        connection = ConnectionConfiguration.getInstance()
+        Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
+                .orElseThrow(() -> new RuntimeException("Unknown connection name: " + connectionName));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteStatement.java
@@ -56,17 +56,11 @@ public class SqlExecuteStatement extends ActionTypeExecution {
         String connectionName = convertConnectionName(getConnectionName().getValue());
         // Get Connection
         Connection connection;
-        try {
-            connection = ConnectionConfiguration.getInstance().get(new ConnectionKey(connectionName, getExecutionControl().getEnvName()))
-                    .orElseThrow(() -> new RuntimeException("Cannot find connection " + connectionName));
-        } catch (Exception e) {
-            throw new RuntimeException("Unknown connection name");
-        }
+        connection = ConnectionConfiguration.getInstance()
+                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
 
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
-        if (database == null) {
-            throw new RuntimeException("Error establishing DB connection");
-        }
 
         // Run the action
         // Make sure the SQL statement is ended with a ;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
@@ -118,19 +118,12 @@ public class WfaExecuteQueryPing extends ActionTypeExecution {
         int waitInterval = convertWaitInterval(getWaitInterval().getValue());
 
         Connection connection;
-        try {
-            connection = ConnectionConfiguration.getInstance()
-                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                    .get();
-        } catch (Exception e) {
-            throw new RuntimeException("Unknown connection name");
-        }
+        connection = ConnectionConfiguration.getInstance()
+                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
 
         ConnectionOperation connectionOperation = new ConnectionOperation();
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
-        if (database == null) {
-            throw new RuntimeException("Error establishing DB connection");
-        }
 
         // Run the action
         int i = 1;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
@@ -117,10 +117,9 @@ public class WfaExecuteQueryPing extends ActionTypeExecution {
         int timeoutInterval = convertTimeoutInterval(getTimeoutInterval().getValue());
         int waitInterval = convertWaitInterval(getWaitInterval().getValue());
 
-        Connection connection;
-        connection = ConnectionConfiguration.getInstance()
+        Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .orElseThrow(() -> new RuntimeException("Unknown connection name"));
+                .orElseThrow(() -> new RuntimeException("Unknown connection name: " + connectionName));
 
         ConnectionOperation connectionOperation = new ConnectionOperation();
         Database database = DatabaseHandler.getInstance().getDatabase(connection);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/wfa/WfaExecuteQueryPing.java
@@ -116,11 +116,21 @@ public class WfaExecuteQueryPing extends ActionTypeExecution {
         boolean setRuntimeVariables = converSetRuntimeVariable(getSetRuntimeVariables().getValue());
         int timeoutInterval = convertTimeoutInterval(getTimeoutInterval().getValue());
         int waitInterval = convertWaitInterval(getWaitInterval().getValue());
-        Connection connection = ConnectionConfiguration.getInstance()
-                .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
-                .get();
+
+        Connection connection;
+        try {
+            connection = ConnectionConfiguration.getInstance()
+                    .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))
+                    .get();
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown connection name");
+        }
+
         ConnectionOperation connectionOperation = new ConnectionOperation();
         Database database = DatabaseHandler.getInstance().getDatabase(connection);
+        if (database == null) {
+            throw new RuntimeException("Error establishing DB connection");
+        }
 
         // Run the action
         int i = 1;

--- a/dev/feature/3424dfb.unknown-connection-sqlexecutequery/HelloWorldScript.yml
+++ b/dev/feature/3424dfb.unknown-connection-sqlexecutequery/HelloWorldScript.yml
@@ -1,0 +1,14 @@
+---
+type: Script
+data:
+  type: "script"
+  name: "helloworld"
+  description: "Hello World Tutorial Script"
+  actions:
+  - number: 1
+    type: "fwk.dummy"
+    name: "HelloWorld"
+    description: "HelloWorld Action"
+    errorExpected: "N"
+    errorStop: "N"
+    parameters: []

--- a/dev/feature/3424dfb.unknown-connection-sqlexecutequery/bigquery1.yml
+++ b/dev/feature/3424dfb.unknown-connection-sqlexecutequery/bigquery1.yml
@@ -1,0 +1,21 @@
+---
+type: "script"
+data:
+  name: "db.bigquery.1"
+  description: "test db.bigquery connection with standard select query"
+  parameters: []
+  actions:
+  - number: 1
+    type: "sql.executeQuery"
+    name: "Action1"
+    description: "Select data from table1 in the iesi schema"
+    component: ""
+    condition: ""
+    iteration: ""
+    errorExpected: "N"
+    errorStop: "N"
+    parameters:
+    - name: "query"
+      value : "select * from iesi.table1;"
+    - name: "connection"
+      value : "db.bigquery.1"

--- a/dev/feature/3424dfb.unknown-connection-sqlexecutequery/bigquery2.yml
+++ b/dev/feature/3424dfb.unknown-connection-sqlexecutequery/bigquery2.yml
@@ -1,0 +1,21 @@
+---
+type: "script"
+data:
+  name: "db.bigquery.2"
+  description: "test db.bigquery connection with standard select query"
+  parameters: []
+  actions:
+  - number: 1
+    type: "sql.executeQuery"
+    name: "Action1"
+    description: "Select data from table1 in the iesi schema"
+    component: ""
+    condition: ""
+    iteration: ""
+    errorExpected: "N"
+    errorStop: "N"
+    parameters:
+    - name: "query"
+      value : "select * from iesi.table1;"
+    - name: "connection"
+      value : "db.bigquery.2"

--- a/dev/feature/3424dfb.unknown-connection-sqlexecutequery/db.bigquery.1.yml
+++ b/dev/feature/3424dfb.unknown-connection-sqlexecutequery/db.bigquery.1.yml
@@ -1,0 +1,22 @@
+---
+type: Connection
+data:
+  name: "db.bigquery.1"
+  type: "db.bigquery"
+  description: "db.bigquery connection"
+  environment: "iesi-dev"
+  parameters:
+  - name: "host"
+    value: "https://www.googleapis.com/bigquery/v2"
+  - name: "port"
+    value: "443"
+  - name: "project"
+    value: "iesi-01"
+  - name: "dataset"
+    value: "iesi"
+  - name: "authMode"
+    value: "service"
+  - name: "serviceAccount"
+    value: ""
+  - name: "keyPath"
+    value: ""

--- a/dev/feature/3424dfb.unknown-connection-sqlexecutequery/iesi-dev.yml
+++ b/dev/feature/3424dfb.unknown-connection-sqlexecutequery/iesi-dev.yml
@@ -1,0 +1,5 @@
+---
+type: Environment
+data:
+  name: "iesi-dev"
+  description: "iesi-dev environment"


### PR DESCRIPTION
Eg in SqlExecuteQuery, the connection is setup and assumed to be ok. Subsequent DB actions on the non existing connecting give nullpointer exceptions. Propose to check connection established and handle exceptions early.

```
DatabaseConnection databaseConnection = connectionOperation
					.getDatabaseConnection(connection);

if(databaseConnection == null) {
	//handle
}
```
**ID**
3424dfb