### PR TITLE
Http Component Header & Query traces have a faulty column name

### DIFF
--- a/core/conf/application-metadata.yml
+++ b/core/conf/application-metadata.yml
@@ -3322,7 +3322,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          HEADER_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentHeaderDesign
             order: 2
             type: string
@@ -3355,7 +3355,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          QUERY_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentQueryDesign
             order: 2
             type: string

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentDesignTraceService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentDesignTraceService.java
@@ -1,5 +1,6 @@
 package io.metadew.iesi.component.http;
 
+import io.metadew.iesi.metadata.configuration.component.trace.ComponentDesignTraceConfiguration;
 import io.metadew.iesi.metadata.definition.component.trace.design.*;
 import io.metadew.iesi.metadata.definition.component.trace.design.http.*;
 import io.metadew.iesi.script.execution.ActionExecution;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentService.java
@@ -12,12 +12,14 @@ import io.metadew.iesi.metadata.configuration.component.ComponentConfiguration;
 import io.metadew.iesi.metadata.definition.component.Component;
 import io.metadew.iesi.metadata.service.connection.trace.http.HttpConnectionTraceService;
 import io.metadew.iesi.script.execution.ActionExecution;
+import lombok.extern.log4j.Log4j2;
 import org.apache.http.entity.ContentType;
 
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.stream.Collectors;
 
+@Log4j2
 public class HttpComponentService implements IHttpComponentService {
 
     private static HttpComponentService INSTANCE;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentTraceService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentTraceService.java
@@ -1,6 +1,6 @@
 package io.metadew.iesi.component.http;
 
-import io.metadew.iesi.metadata.definition.component.trace.ComponentTraceConfiguration;
+import io.metadew.iesi.metadata.configuration.component.trace.ComponentTraceConfiguration;
 import io.metadew.iesi.metadata.definition.component.trace.ComponentTraceKey;
 import io.metadew.iesi.metadata.definition.component.trace.http.*;
 import io.metadew.iesi.script.execution.ActionExecution;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/component/trace/ComponentDesignTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/component/trace/ComponentDesignTraceConfiguration.java
@@ -1,9 +1,11 @@
-package io.metadew.iesi.metadata.definition.component.trace.design;
+package io.metadew.iesi.metadata.configuration.component.trace;
 
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
 import io.metadew.iesi.common.configuration.metadata.tables.MetadataTablesConfiguration;
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
+import io.metadew.iesi.metadata.definition.component.trace.design.ComponentDesignTrace;
+import io.metadew.iesi.metadata.definition.component.trace.design.ComponentDesignTraceKey;
 import io.metadew.iesi.metadata.definition.component.trace.design.http.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,7 +31,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
     }
 
     private ComponentDesignTraceConfiguration() {
-        setMetadataRepository(MetadataRepositoryConfiguration.getInstance().getDesignMetadataRepository());
+        setMetadataRepository(MetadataRepositoryConfiguration.getInstance().getTraceMetadataRepository());
     }
 
     @Override
@@ -41,16 +43,16 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
                     "TraceComponentDesign.COMP_TYP_NM as TraceComponentDesign_COMP_TYP_NM, TraceComponentDesign.COMP_NM as TraceComponentDesign_COMP_NM, " +
                     "TraceComponentDesign.COMP_DSC as TraceComponentDesign_COMP_DSC, TraceComponentDesign.COMP_VRS_NB as TraceComponentDesign_COMP_VRS_NB, " +
                     " TraceHttpComponentDesign.ID as TraceHttpComponentDesign_ID, TraceHttpComponentDesign.CONN_NM as TraceHttpComponentDesign_CONN_NM, TraceHttpComponentDesign.TYPE as TraceHttpComponentDesign_TYPE, TraceHttpComponentDesign.ENDPOINT as TraceHttpComponentDesign_ENDPOINT, " +
-                    " TraceHttpComponentHeaderDesign.ID as TraceHttpComponentHeaderDesign_ID, TraceHttpComponentHeaderDesign.HEADER_DES_ID as TraceHttpComponentHeaderDesign_HEADER_DES_ID, TraceHttpComponentHeaderDesign.NAME as TraceHttpComponentHeaderDesign_NAME , TraceHttpComponentHeaderDesign.VALUE as TraceHttpComponentHeaderDesign_VALUE, " +
-                    " TraceHttpComponentQueryDesign.ID as TraceHttpComponentQueryDesign_ID, TraceHttpComponentQueryDesign.QUERY_DES_ID as TraceHttpComponentQueryDesign_QUERY_DES_ID, TraceHttpComponentQueryDesign.NAME as TraceHttpComponentQueryDesign_NAME, TraceHttpComponentQueryDesign.VALUE as TraceHttpComponentQueryDesign_VALUE" +
+                    " TraceHttpComponentHeaderDesign.ID as TraceHttpComponentHeaderDesign_ID, TraceHttpComponentHeaderDesign.HTTP_COMP_DES_ID as TraceHttpComponentHeaderDesign_HTTP_COMP_DES_ID, TraceHttpComponentHeaderDesign.NAME as TraceHttpComponentHeaderDesign_NAME , TraceHttpComponentHeaderDesign.VALUE as TraceHttpComponentHeaderDesign_VALUE, " +
+                    " TraceHttpComponentQueryDesign.ID as TraceHttpComponentQueryDesign_ID, TraceHttpComponentQueryDesign.HTTP_COMP_DES_ID as TraceHttpComponentQueryDesign_HTTP_COMP_DES_ID, TraceHttpComponentQueryDesign.NAME as TraceHttpComponentQueryDesign_NAME, TraceHttpComponentQueryDesign.VALUE as TraceHttpComponentQueryDesign_VALUE" +
                     " FROM " +
                     MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceComponentDesign").getName() + " TraceComponentDesign " +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentDesign").getName() + " TraceHttpComponentDesign " +
                     "on TraceComponentDesign.ID=TraceHttpComponentDesign.ID " +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentHeaderDesign").getName() + " TraceHttpComponentHeaderDesign " +
-                    "on TraceHttpComponentDesign.ID=TraceHttpComponentHeaderDesign.HEADER_DES_ID " +
+                    "on TraceHttpComponentDesign.ID=TraceHttpComponentHeaderDesign.HTTP_COMP_DES_ID " +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentQueryDesign").getName() + " TraceHttpComponentQueryDesign " +
-                    "on TraceHttpComponentDesign.ID=TraceHttpComponentQueryDesign.QUERY_DES_ID " +
+                    "on TraceHttpComponentDesign.ID=TraceHttpComponentQueryDesign.HTTP_COMP_DES_ID " +
                     " WHERE TraceComponentDesign.ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
 
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
@@ -73,16 +75,16 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
                     "TraceComponentDesign.COMP_TYP_NM as TraceComponentDesign_COMP_TYP_NM, TraceComponentDesign.COMP_NM as TraceComponentDesign_COMP_NM, " +
                     "TraceComponentDesign.COMP_DSC as TraceComponentDesign_COMP_DSC, TraceComponentDesign.COMP_VRS_NB as TraceComponentDesign_COMP_VRS_NB, " +
                     " TraceHttpComponentDesign.ID as TraceHttpComponentDesign_ID, TraceHttpComponentDesign.CONN_NM as TraceHttpComponentDesign_CONN_NM, TraceHttpComponentDesign.TYPE as TraceHttpComponentDesign_TYPE, TraceHttpComponentDesign.ENDPOINT as TraceHttpComponentDesign_ENDPOINT, " +
-                    " TraceHttpComponentHeaderDesign.ID as TraceHttpComponentHeaderDesign_ID, TraceHttpComponentHeaderDesign.HEADER_DES_ID as TraceHttpComponentHeaderDesign_HEADER_DES_ID, TraceHttpComponentHeaderDesign.NAME as TraceHttpComponentHeaderDesign_NAME , TraceHttpComponentHeaderDesign.VALUE as TraceHttpComponentHeaderDesign_VALUE, " +
-                    " TraceHttpComponentQueryDesign.ID as TraceHttpComponentQueryDesign_ID, TraceHttpComponentQueryDesign.QUERY_DES_ID as TraceHttpComponentQueryDesign_QUERY_DES_ID, TraceHttpComponentQueryDesign.NAME as TraceHttpComponentQueryDesign_NAME, TraceHttpComponentQueryDesign.VALUE as TraceHttpComponentQueryDesign_VALUE" +
+                    " TraceHttpComponentHeaderDesign.ID as TraceHttpComponentHeaderDesign_ID, TraceHttpComponentHeaderDesign.HTTP_COMP_DES_ID as TraceHttpComponentHeaderDesign_HTTP_COMP_DES_ID, TraceHttpComponentHeaderDesign.NAME as TraceHttpComponentHeaderDesign_NAME , TraceHttpComponentHeaderDesign.VALUE as TraceHttpComponentHeaderDesign_VALUE, " +
+                    " TraceHttpComponentQueryDesign.ID as TraceHttpComponentQueryDesign_ID, TraceHttpComponentQueryDesign.HTTP_COMP_DES_ID as TraceHttpComponentQueryDesign_HTTP_COMP_DES_ID, TraceHttpComponentQueryDesign.NAME as TraceHttpComponentQueryDesign_NAME, TraceHttpComponentQueryDesign.VALUE as TraceHttpComponentQueryDesign_VALUE" +
                     " FROM " +
                     MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceComponentDesign").getName() + " TraceComponentDesign" +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentDesign").getName() + " TraceHttpComponentDesign " +
                     "on TraceComponentDesign.ID=TraceHttpComponentDesign.ID " +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentHeaderDesign").getName() + " TraceHttpComponentHeaderDesign " +
-                    "on TraceHttpComponentDesign.ID=TraceHttpComponentHeaderDesign.HEADER_DES_ID " +
+                    "on TraceHttpComponentDesign.ID=TraceHttpComponentHeaderDesign.HTTP_COMP_DES_ID " +
                     " left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentQueryDesign").getName() + " TraceHttpComponentQueryDesign " +
-                    "on TraceHttpComponentDesign.ID=TraceHttpComponentQueryDesign.QUERY_DES_ID " + ";";
+                    "on TraceHttpComponentDesign.ID=TraceHttpComponentQueryDesign.HTTP_COMP_DES_ID " + ";";
 
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(query, "reader");
             while (cachedRowSet.next()) {
@@ -98,6 +100,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
 
     @Override
     public void delete(ComponentDesignTraceKey metadataKey) {
+        log.trace("deleting " + metadataKey.toString());
         String deleteTraceComponentDesign = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceComponentDesign").getName() +
                 " WHERE ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
         getMetadataRepository().executeUpdate(deleteTraceComponentDesign);
@@ -105,10 +108,10 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
                 " WHERE ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
         getMetadataRepository().executeUpdate(deleteTraceHttpComponentDesign);
         String deleteTraceHttpComponentHeaderDesign = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentHeaderDesign").getName() +
-                " WHERE HEADER_DES_ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
+                " WHERE HTTP_COMP_DES_ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
         getMetadataRepository().executeUpdate(deleteTraceHttpComponentHeaderDesign);
         String deleteTraceHttpComponentQueryDesign = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentQueryDesign").getName() +
-                " WHERE QUERY_DES_ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
+                " WHERE HTTP_COMP_DES_ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
         getMetadataRepository().executeUpdate(deleteTraceHttpComponentQueryDesign);
     }
 
@@ -116,7 +119,6 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
     @Override
     public void insert(HttpComponentDesignTrace metadata) {
         log.trace(MessageFormat.format("Inserting {0}.", metadata.toString()));
-
         String insertStatementTraceComponentDesign = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceComponentDesign").getName() +
                 " (ID, RUN_ID,  PRC_ID, ACTION_PAR_NM, COMP_TYP_NM, COMP_NM, COMP_DSC, COMP_VRS_NB ) VALUES (" +
                 SQLTools.GetStringForSQL(metadata.getMetadataKey().getUuid()) + ", " +
@@ -143,7 +145,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
         metadata.getHttpComponentHeaderDesigns().forEach(httpComponentHeaderTrace ->
                 getMetadataRepository().executeUpdate(
                         "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentHeaderDesign").getName() +
-                                " (ID, HEADER_DES_ID, NAME, VALUE ) VALUES " +
+                                " (ID, HTTP_COMP_DES_ID, NAME, VALUE ) VALUES " +
                                 " ( " +
                                 SQLTools.GetStringForSQL(httpComponentHeaderTrace.getMetadataKey().getUuid().toString()) + ", " +
                                 SQLTools.GetStringForSQL(httpComponentHeaderTrace.getHttpComponentDesignID().getUuid().toString()) + ", " +
@@ -154,7 +156,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
         metadata.getHttpComponentQueryDesigns().forEach(httpComponentQueryTrace ->
                 getMetadataRepository().executeUpdate(
                         "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceHttpComponentQueryDesign").getName() +
-                                " (ID, QUERY_DES_ID,  NAME, VALUE )  VALUES " +
+                                " (ID, HTTP_COMP_DES_ID,  NAME, VALUE )  VALUES " +
                                 " ( " +
                                 SQLTools.GetStringForSQL(httpComponentQueryTrace.getMetadataKey().getUuid().toString()) + ", " +
                                 SQLTools.GetStringForSQL(httpComponentQueryTrace.getHttpComponentQueryDesignID().getUuid().toString()) + ", " +
@@ -197,7 +199,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
                     mapHttpComponentHeaderDesignsId,
                     new HttpComponentHeaderDesignTrace(
                             new HttpComponentHeaderDesignTraceKey(UUID.fromString(mapHttpComponentHeaderDesignsId)),
-                            new ComponentDesignTraceKey(UUID.fromString(cachedRowSet.getString("TraceHttpComponentHeaderDesign_HEADER_DES_ID"))),
+                            new ComponentDesignTraceKey(UUID.fromString(cachedRowSet.getString("TraceHttpComponentHeaderDesign_HTTP_COMP_DES_ID"))),
                             cachedRowSet.getString("TraceHttpComponentHeaderDesign_NAME"),
                             cachedRowSet.getString("TraceHttpComponentHeaderDesign_VALUE")
                     )
@@ -212,7 +214,7 @@ public class ComponentDesignTraceConfiguration extends Configuration<HttpCompone
                     httpComponentDesignQueryId,
                     new HttpComponentQueryParameterDesignTrace(
                         new HttpComponentQueryParameterDesignTraceKey(UUID.fromString(httpComponentDesignQueryId)),
-                            new ComponentDesignTraceKey(UUID.fromString(cachedRowSet.getString("TraceHttpComponentQueryDesign_QUERY_DES_ID"))),
+                            new ComponentDesignTraceKey(UUID.fromString(cachedRowSet.getString("TraceHttpComponentQueryDesign_HTTP_COMP_DES_ID"))),
                             cachedRowSet.getString("TraceHttpComponentQueryDesign_NAME"),
                             cachedRowSet.getString("TraceHttpComponentQueryDesign_VALUE")
                     )

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/component/trace/ComponentTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/component/trace/ComponentTraceConfiguration.java
@@ -1,9 +1,11 @@
-package io.metadew.iesi.metadata.definition.component.trace;
+package io.metadew.iesi.metadata.configuration.component.trace;
 
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
 import io.metadew.iesi.common.configuration.metadata.tables.MetadataTablesConfiguration;
 import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.metadata.configuration.Configuration;
+import io.metadew.iesi.metadata.definition.component.trace.ComponentTrace;
+import io.metadew.iesi.metadata.definition.component.trace.ComponentTraceKey;
 import io.metadew.iesi.metadata.definition.component.trace.http.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,7 +32,7 @@ public class ComponentTraceConfiguration extends Configuration<ComponentTrace, C
     }
 
     private ComponentTraceConfiguration() {
-        setMetadataRepository(MetadataRepositoryConfiguration.getInstance().getDesignMetadataRepository());
+        setMetadataRepository(MetadataRepositoryConfiguration.getInstance().getTraceMetadataRepository());
     }
 
 
@@ -101,6 +103,7 @@ public class ComponentTraceConfiguration extends Configuration<ComponentTrace, C
 
     @Override
     public void delete(ComponentTraceKey metadataKey) {
+        log.trace("deleting " + metadataKey.toString());
         String deleteTraceComponent = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("TraceComponent").getName() +
                 " WHERE ID = " + SQLTools.GetStringForSQL(metadataKey.getUuid().toString()) + ";";
         getMetadataRepository().executeUpdate(deleteTraceComponent);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/connection/trace/ConnectionTraceConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/connection/trace/ConnectionTraceConfiguration.java
@@ -7,6 +7,7 @@ import io.metadew.iesi.metadata.configuration.Configuration;
 import io.metadew.iesi.metadata.definition.connection.trace.ConnectionTrace;
 import io.metadew.iesi.metadata.definition.connection.trace.ConnectionTraceKey;
 import io.metadew.iesi.metadata.definition.connection.trace.http.HttpConnectionTrace;
+import lombok.extern.log4j.Log4j2;
 
 import javax.sql.rowset.CachedRowSet;
 import java.sql.SQLException;
@@ -16,9 +17,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Log4j2
 public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace, ConnectionTraceKey> {
 
-    private static String fetchByIdQuery = "SELECT " +
+    private static final String fetchByIdQuery = "SELECT " +
             "connection_traces.ID as connection_traces_id, connection_traces.RUN_ID as connection_traces_run_id, " +
             "connection_traces.PRC_ID as connection_traces_prc_id, connection_traces.ACTION_PAR_NM as connection_traces_action_par_nm, " +
             "connection_traces.CONN_NM as connection_traces_conn_nm, connection_traces.CONN_TYP_NM as connection_traces_conn_type_nm, " +
@@ -30,7 +32,7 @@ public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace,
             "LEFT OUTER JOIN " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() + " http_connection_traces " +
             "ON connection_traces.ID=http_connection_traces.ID " +
             "WHERE connection_traces.ID={0};";
-    private static String fetchAllQuery = "SELECT " +
+    private static final String fetchAllQuery = "SELECT " +
             "connection_traces.ID as connection_traces_id, connection_traces.RUN_ID as connection_traces_run_id, " +
             "connection_traces.PRC_ID as connection_traces_prc_id, connection_traces.ACTION_PAR_NM as connection_traces_action_par_nm, " +
             "connection_traces.CONN_NM as connection_traces_conn_nm, connection_traces.CONN_TYP_NM as connection_traces_conn_type_nm, " +
@@ -41,13 +43,13 @@ public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace,
             "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("ConnectionTraces").getName() + " connection_traces " +
             "LEFT OUTER JOIN " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() + " http_connection_traces " +
             "ON connection_traces.ID=http_connection_traces.ID;";
-    private static String insertQuery = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("ConnectionTraces").getName() +
+    private static final String insertQuery = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("ConnectionTraces").getName() +
             " (ID, RUN_ID, PRC_ID, ACTION_PAR_NM, CONN_NM, CONN_TYP_NM, CONN_DESC) VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6});";
-    private static String insertHttpQuery = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() +
+    private static final String insertHttpQuery = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() +
             " (ID, HOST, PORT, BASE_URL, TLS) VALUES ({0}, {1}, {2}, {3}, {4});";
-    private static String deleteByIdQuery = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("ConnectionTraces").getName() +
+    private static final String deleteByIdQuery = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("ConnectionTraces").getName() +
             " WHERE ID={0};";
-    private static String deleteByIdHttpQuery = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() +
+    private static final String deleteByIdHttpQuery = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("HttpConnectionTraces").getName() +
             " WHERE ID={0};";
 
     private static ConnectionTraceConfiguration INSTANCE;
@@ -100,6 +102,7 @@ public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace,
 
     @Override
     public void delete(ConnectionTraceKey metadataKey) {
+        log.trace("deleting " + metadataKey.toString());
         getMetadataRepository().executeUpdate(
                 MessageFormat.format(deleteByIdQuery,
                         SQLTools.GetStringForSQL(metadataKey.getUuid()))
@@ -112,6 +115,7 @@ public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace,
 
     @Override
     public void insert(ConnectionTrace metadata) {
+        log.info("inserting " + metadata.toString());
         getMetadataRepository().executeUpdate(
                 MessageFormat.format(insertQuery,
                         SQLTools.GetStringForSQL(metadata.getMetadataKey().getUuid()),
@@ -123,6 +127,7 @@ public class ConnectionTraceConfiguration extends Configuration<ConnectionTrace,
                         SQLTools.GetStringForSQL(metadata.getDescription())
                 ));
         if (metadata instanceof HttpConnectionTrace) {
+            log.info("inserting http connection" + metadata.toString());
             getMetadataRepository().executeUpdate(
                     MessageFormat.format(insertHttpQuery,
                             SQLTools.GetStringForSQL(metadata.getMetadataKey().getUuid()),

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/connection/trace/ConnectionTrace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/connection/trace/ConnectionTrace.java
@@ -4,9 +4,11 @@ import io.metadew.iesi.metadata.definition.Metadata;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class ConnectionTrace extends Metadata<ConnectionTraceKey> {
 
     private final String runId;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/connection/trace/http/HttpConnectionTrace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/definition/connection/trace/http/HttpConnectionTrace.java
@@ -5,9 +5,11 @@ import io.metadew.iesi.metadata.definition.connection.trace.ConnectionTraceKey;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class HttpConnectionTrace extends ConnectionTrace {
 
     private final String host;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/connection/trace/http/HttpConnectionTraceService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/service/connection/trace/http/HttpConnectionTraceService.java
@@ -5,9 +5,11 @@ import io.metadew.iesi.metadata.configuration.connection.trace.ConnectionTraceCo
 import io.metadew.iesi.metadata.definition.connection.trace.ConnectionTraceKey;
 import io.metadew.iesi.metadata.definition.connection.trace.http.HttpConnectionTrace;
 import io.metadew.iesi.script.execution.ActionExecution;
+import lombok.extern.log4j.Log4j2;
 
 import java.util.UUID;
 
+@Log4j2
 public class HttpConnectionTraceService implements IHttpConnectionTraceService {
     private static final String CONNECTION_TYPE = "http";
 
@@ -24,8 +26,8 @@ public class HttpConnectionTraceService implements IHttpConnectionTraceService {
     }
 
     public HttpConnectionTrace convert(HttpConnection httpConnection, ActionExecution actionExecution, String actionParameterName) {
-        return HttpConnectionTrace.builder().
-                metadataKey(new ConnectionTraceKey(UUID.randomUUID()))
+        return HttpConnectionTrace.builder()
+                .metadataKey(new ConnectionTraceKey(UUID.randomUUID()))
                 .runId(actionExecution.getExecutionControl().getRunId())
                 .processId(actionExecution.getProcessId())
                 .actionParameter(actionParameterName)
@@ -40,7 +42,8 @@ public class HttpConnectionTraceService implements IHttpConnectionTraceService {
     }
 
     public void trace(HttpConnection httpConnection, ActionExecution actionExecution, String actionParameterName) {
-        ConnectionTraceConfiguration.getInstance().insert(convert(httpConnection, actionExecution, actionParameterName));
+        HttpConnectionTrace httpConnectionTrace = convert(httpConnection, actionExecution, actionParameterName);
+        ConnectionTraceConfiguration.getInstance().insert(httpConnectionTrace);
     }
 
 }

--- a/core/java/iesi-core/src/main/resources/application-metadata.yml
+++ b/core/java/iesi-core/src/main/resources/application-metadata.yml
@@ -3322,7 +3322,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          HEADER_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentHeaderDesign
             order: 2
             type: string
@@ -3355,7 +3355,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          QUERY_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentQueryDesign
             order: 2
             type: string

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/HttpConnectionTraceServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/HttpConnectionTraceServiceTest.java
@@ -1,0 +1,30 @@
+package io.metadew.iesi.connection.http;
+
+import io.metadew.iesi.script.execution.ActionExecution;
+import io.metadew.iesi.script.execution.ExecutionControl;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpConnectionTraceServiceTest {
+
+    @Test
+    void test() {
+        ActionExecution actionExecution = mock(ActionExecution.class);
+        ExecutionControl executionControl = mock(ExecutionControl.class);
+        when(actionExecution.getExecutionControl())
+                .thenReturn(executionControl);
+        when(actionExecution.getProcessId())
+                .thenReturn(1L);
+        when(executionControl.getRunId())
+                .thenReturn("runId");
+//        HttpConnectionTraceService.getInstance().trace(
+//                new HttpConnection("referenceName", "description", "environment", "host", "baseurl", 8080, true),
+//                actionExecution,
+//                "test"
+//        );
+        //ConnectionTraceConfiguration.getInstance().insert(HttpConnectionTrace.builder().build());
+    }
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/definition/ComponentDesignTraceConfigurationTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/definition/ComponentDesignTraceConfigurationTest.java
@@ -2,6 +2,7 @@ package io.metadew.iesi.metadata.definition;
 
 import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
+import io.metadew.iesi.metadata.configuration.component.trace.ComponentDesignTraceConfiguration;
 import io.metadew.iesi.metadata.definition.component.trace.design.*;
 import io.metadew.iesi.metadata.definition.component.trace.design.http.*;
 import org.junit.jupiter.api.*;

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/definition/ComponentTraceConfigurationTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/definition/ComponentTraceConfigurationTest.java
@@ -2,6 +2,7 @@ package io.metadew.iesi.metadata.definition;
 
 import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
+import io.metadew.iesi.metadata.configuration.component.trace.ComponentTraceConfiguration;
 import io.metadew.iesi.metadata.definition.component.trace.*;
 import io.metadew.iesi.metadata.definition.component.trace.http.*;
 import org.junit.jupiter.api.*;

--- a/core/java/iesi-core/src/test/resources/application-metadata.yml
+++ b/core/java/iesi-core/src/test/resources/application-metadata.yml
@@ -3322,7 +3322,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          HEADER_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentHeaderDesign
             order: 2
             type: string
@@ -3355,7 +3355,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          QUERY_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentQueryDesign
             order: 2
             type: string

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-metadata.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-metadata.yml
@@ -3322,7 +3322,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          HEADER_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentHeaderDesign
             order: 2
             type: string
@@ -3355,7 +3355,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          QUERY_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentQueryDesign
             order: 2
             type: string

--- a/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-metadata.yml
+++ b/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-metadata.yml
@@ -3322,7 +3322,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          HEADER_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentHeaderDesign
             order: 2
             type: string
@@ -3355,7 +3355,7 @@ iesi:
             length: 255
             nullable: false
             primaryKey: true
-          QUERY_DES_ID:
+          HTTP_COMP_DES_ID:
             description: Unique short name for the TraceHttpComponentQueryDesign
             order: 2
             type: string


### PR DESCRIPTION
**Describe the bug**
The table for TraceHttpComponentHeaderDesign and TraceHttpComponentQueryDesign have columns HEADER_DES_ID and QUERY_DES_ID that should be renamed to HTTP_COMP_DES_ID

**id**
 c68ec60