### PR TITLE
Handle empty JSON response

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityService.java
@@ -45,10 +45,14 @@ public class ApplicationJsonHttpResponseEntityService implements IHttpResponseEn
                     .map(contentType -> Optional.ofNullable(contentType.getCharset())
                             .orElse(Consts.UTF_8))
                     .orElse(Consts.UTF_8);
-            log.debug("raw JSON content: " + new String(httpResponse.getEntityContent().get(), charset));
-            JsonNode jsonNode = new ObjectMapper().readTree(new String(httpResponse.getEntityContent().get(), charset));
-            //DatasetHandler.getInstance().clean(dataset, executionRuntime);
-            DatasetHandler.getInstance().setDataItem(dataset, key, DataTypeHandler.getInstance().resolve(dataset, key, jsonNode, executionRuntime));
+            String jsonContent = new String(httpResponse.getEntityContent().get(), charset);
+            log.debug("raw JSON content: " + jsonContent);
+            JsonNode jsonNode = new ObjectMapper().readTree(jsonContent);
+            if (jsonNode == null) {
+                log.warn("response does not contain a valid JSON message: " + jsonContent + ". ");
+            } else {
+                DatasetHandler.getInstance().setDataItem(dataset, key, DataTypeHandler.getInstance().resolve(dataset, key, jsonNode, executionRuntime));
+            }
         }
     }
 

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
@@ -1,0 +1,29 @@
+package io.metadew.iesi.connection.http.entity.json;
+
+import io.metadew.iesi.connection.http.response.HttpResponse;
+import io.metadew.iesi.datatypes.dataset.DatasetHandler;
+import io.metadew.iesi.datatypes.dataset.keyvalue.KeyValueDataset;
+import io.metadew.iesi.script.execution.ExecutionRuntime;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Mockito.mock;
+
+class ApplicationJsonHttpResponseEntityServiceTest {
+
+    @Test
+    void writeToDatasetTest() {
+        DatasetHandler datasetHandler = DatasetHandler.getInstance();
+        DatasetHandler datasetHandlerSpy = Mockito.spy(datasetHandler);
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandlerSpy);
+
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        KeyValueDataset dataset = mock(KeyValueDataset.class);
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", (DatasetHandler) null);
+    }
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
@@ -29,7 +29,6 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
         Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
 
-
         HttpResponse httpResponse = mock(HttpResponse.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
         when(httpResponse.getEntityContent())
@@ -59,7 +58,6 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
         Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
 
-
         HttpResponse httpResponse = mock(HttpResponse.class);
         when(httpResponse.getEntityContent())
                 .thenReturn(Optional.of(new String("{\"test\":\"test\"}".getBytes(Consts.UTF_8), Consts.UTF_8).getBytes(Consts.UTF_8)));
@@ -85,7 +83,6 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandler);
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
         Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
-
 
         HttpResponse httpResponse = mock(HttpResponse.class);
         HttpEntity httpEntity = mock(HttpEntity.class);

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
@@ -1,29 +1,108 @@
 package io.metadew.iesi.connection.http.entity.json;
 
 import io.metadew.iesi.connection.http.response.HttpResponse;
+import io.metadew.iesi.datatypes.DataTypeHandler;
 import io.metadew.iesi.datatypes.dataset.DatasetHandler;
 import io.metadew.iesi.datatypes.dataset.keyvalue.KeyValueDataset;
+import io.metadew.iesi.datatypes.text.Text;
 import io.metadew.iesi.script.execution.ExecutionRuntime;
+import org.apache.http.Consts;
+import org.apache.http.HttpEntity;
+import org.apache.http.message.BasicHeader;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
-import static org.mockito.Mockito.mock;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 class ApplicationJsonHttpResponseEntityServiceTest {
 
     @Test
-    void writeToDatasetTest() {
-        DatasetHandler datasetHandler = DatasetHandler.getInstance();
-        DatasetHandler datasetHandlerSpy = Mockito.spy(datasetHandler);
-        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandlerSpy);
+    void writeToDatasetTest() throws IOException {
+        // Setup
+        DatasetHandler datasetHandler = mock(DatasetHandler.class);
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandler);
+        DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+
 
         HttpResponse httpResponse = mock(HttpResponse.class);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(httpResponse.getEntityContent())
+                .thenReturn(Optional.of(new String("{\"test\":\"test\"}".getBytes(Consts.ASCII), Consts.ASCII).getBytes(Consts.ASCII)));
+        when(httpEntity.getContentType())
+                .thenReturn(new BasicHeader("Content-Type", Consts.ASCII.toString()));
         KeyValueDataset dataset = mock(KeyValueDataset.class);
         ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
 
+        when(dataTypeHandler
+                .resolve(eq(dataset), eq("key"), any(), eq(executionRuntime)))
+                .thenReturn(new Text("test"));
+        // Test
+        ApplicationJsonHttpResponseEntityService.getInstance().writeToDataset(httpResponse, dataset, "key", executionRuntime);
+        verify(datasetHandler, times(1)).setDataItem(dataset, "key", new Text("test"));
 
+        // Clean up
         Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", (DatasetHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
+    }
+
+    @Test
+    void writeToDatasetNoCharsetTest() throws IOException {
+        // Setup
+        DatasetHandler datasetHandler = mock(DatasetHandler.class);
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandler);
+        DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+
+
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        when(httpResponse.getEntityContent())
+                .thenReturn(Optional.of(new String("{\"test\":\"test\"}".getBytes(Consts.UTF_8), Consts.UTF_8).getBytes(Consts.UTF_8)));
+        KeyValueDataset dataset = mock(KeyValueDataset.class);
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        when(dataTypeHandler
+                .resolve(eq(dataset), eq("key"), any(), eq(executionRuntime)))
+                .thenReturn(new Text("test"));
+        // Test
+        ApplicationJsonHttpResponseEntityService.getInstance().writeToDataset(httpResponse, dataset, "key", executionRuntime);
+        verify(datasetHandler, times(1)).setDataItem(dataset, "key", new Text("test"));
+
+        // Clean up
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", (DatasetHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
+    }
+
+    @Test
+    void writeToDatasetInvalidJsonTest() throws IOException {
+        // Setup
+        DatasetHandler datasetHandler = mock(DatasetHandler.class);
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", datasetHandler);
+        DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+
+
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(httpResponse.getEntityContent())
+                .thenReturn(Optional.of(new String("".getBytes(Consts.UTF_8), Consts.UTF_8).getBytes(Consts.UTF_8)));
+        when(httpEntity.getContentType())
+                .thenReturn(new BasicHeader("Content-Type", Consts.UTF_8.toString()));
+        KeyValueDataset dataset = mock(KeyValueDataset.class);
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        // Test
+        ApplicationJsonHttpResponseEntityService.getInstance().writeToDataset(httpResponse, dataset, "key", executionRuntime);
+        verify(dataTypeHandler, times(0)).resolve(eq(dataset), eq("key"), any(), eq(executionRuntime));
+        verify(datasetHandler, times(0)).setDataItem(dataset, "key", new Text("test"));
+        // Clean up
+        Whitebox.setInternalState(DatasetHandler.class, "INSTANCE", (DatasetHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
     }
 
 }


### PR DESCRIPTION
**Describe the bug**
When an API returns an empty string as a JSON response, the framework throws a NullPointerExcpetion. Instead the framework should log a warning and continue the execution.

**Id**
b1cced5