### PR TITLE
allow only defining begin index for text.substring

### DIFF
--- a/core/java/iesi-core/pom.xml
+++ b/core/java/iesi-core/pom.xml
@@ -293,12 +293,6 @@
             <version>3.16.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/java/iesi-core/pom.xml
+++ b/core/java/iesi-core/pom.xml
@@ -293,6 +293,12 @@
             <version>3.16.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -52,27 +52,17 @@ public class TextSubstring implements DataInstruction {
 
 
     public String substring(String string, int beginIndex, int endIndex){
-        if (beginIndex <= 0 || endIndex > string.length()) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less or equals to 0 and endIndex cannot be greater than string.length {1}", beginIndex, endIndex));
-        }else{
             return string.substring(beginIndex-1,endIndex);
-        }
     }
 
     public String substring(String string, int beginIndex){
-        if (beginIndex <= 0 ) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less or equal to 0", beginIndex));
-        }else{
             String s1 = string.substring(beginIndex-1);
-            List<String> collect ;
+            List<String> collect;
 
             collect = Arrays.asList(s1.split("\\b"))
                     .stream().filter(s-> s.matches("\\w+"))
                     .collect(Collectors.toList());
-
             return collect.get(0);
-        }
-
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -28,6 +28,12 @@ public class TextSubstring implements DataInstruction {
             int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR))-1;
             int end = Integer.parseInt(inputParameterMatcher.group(THIRD_OPERATOR));
 
+            if (start < 0)
+                start += text.length()+1;
+
+            if (end < 0)
+                end += text.length()+1 ;
+
             verifyArguments(text, start, end);
             return text.substring(start, end);
 
@@ -35,6 +41,9 @@ public class TextSubstring implements DataInstruction {
 
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
             int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR))-1;
+
+            if (start < 0)
+                start += text.length()+1;
 
             verifyArguments(text, start);
             return text.substring(start);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -65,6 +65,9 @@ public class TextSubstring implements DataInstruction {
             return collect.get(0);
     }
 
+
+
+
     @Override
     public String getKeyword() {
         return "text.substring";

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -56,10 +56,11 @@ public class TextSubstring implements DataInstruction {
 
     public String substring(String string, int beginIndex){
         String s1 = string.substring(beginIndex-1);
-        List<String> list = new ArrayList<>();
         List<String> collect = new ArrayList<>();
-        list = Arrays.asList(s1.split("\\b"));
-        collect = list.stream().filter(s-> s.matches("\\w+")).collect(Collectors.toList());
+
+        collect = Arrays.asList(s1.split("\\b"))
+                .stream().filter(s-> s.matches("\\w+"))
+                .collect(Collectors.toList());
 
         return collect.get(0);
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -3,8 +3,12 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class TextSubstring implements DataInstruction {
 
@@ -44,6 +48,20 @@ public class TextSubstring implements DataInstruction {
         if (start > end) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be greater than end {1}", start, end));
         }
+    }
+
+    public String substring(String string, int beginIndex, int endIndex){
+        return string.substring(beginIndex-1,endIndex);
+    }
+
+    public String substring(String string, int beginIndex){
+        String s1 = string.substring(beginIndex-1);
+        List<String> list = new ArrayList<>();
+        List<String> collect = new ArrayList<>();
+        list = Arrays.asList(s1.split("\\b"));
+        collect = list.stream().filter(s-> s.matches("\\w+")).collect(Collectors.toList());
+
+        return collect.get(0);
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -51,19 +51,28 @@ public class TextSubstring implements DataInstruction {
     }
 
 
-    public static String substring(String string, int beginIndex, int endIndex){
-        return string.substring(beginIndex-1,endIndex);
+    public String substring(String string, int beginIndex, int endIndex){
+        if (beginIndex < 0 || endIndex > string.length()) {
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less than 0 and endIndex cannot be greater than string.length {1}", beginIndex, endIndex));
+        }else{
+            return string.substring(beginIndex-1,endIndex);
+        }
     }
 
-    public static String substring(String string, int beginIndex){
-        String s1 = string.substring(beginIndex-1);
-        List<String> collect ;
+    public String substring(String string, int beginIndex){
+        if (beginIndex <= 0 ) {
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less or equal to 0", beginIndex));
+        }else{
+            String s1 = string.substring(beginIndex-1);
+            List<String> collect ;
 
-        collect = Arrays.asList(s1.split("\\b"))
-                .stream().filter(s-> s.matches("\\w+"))
-                .collect(Collectors.toList());
+            collect = Arrays.asList(s1.split("\\b"))
+                    .stream().filter(s-> s.matches("\\w+"))
+                    .collect(Collectors.toList());
 
-        return collect.get(0);
+            return collect.get(0);
+        }
+
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -57,7 +57,7 @@ public class TextSubstring implements DataInstruction {
 
     public static String substring(String string, int beginIndex){
         String s1 = string.substring(beginIndex-1);
-        List<String> collect = new ArrayList<>();
+        List<String> collect ;
 
         collect = Arrays.asList(s1.split("\\b"))
                 .stream().filter(s-> s.matches("\\w+"))

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -9,44 +9,35 @@ import java.util.regex.Pattern;
 
 public class TextSubstring implements DataInstruction {
 
-    private final String FIRST_OPERATOR = "text";
-    private final String SECOND_OPERATOR = "start";
-    private final String THIRD_OPERATOR = "end";
-    private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
+    private final static String FIRST_OPERATOR = "text";
+    private final static String SECOND_OPERATOR = "start";
+    private final static String THIRD_OPERATOR = "end";
+    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
             "\\s*(?<" + SECOND_OPERATOR + ">-?\\d+)\\s*,\\s*(?<" + THIRD_OPERATOR + ">-?\\d+)\\s*");
 
-    private final Pattern INPUT_PARAMETER_PATTERN_TWO_ARGUMENTS = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
+    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
             "\\s*(?<" + SECOND_OPERATOR + ">-?\\d+)\\s*");
 
     @Override
     public String generateOutput(String parameters) {
-        Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
-        Matcher inputParameterMatcherTwoArguments = INPUT_PARAMETER_PATTERN_TWO_ARGUMENTS.matcher(parameters);
+        Matcher inputParameterMatcher = THREE_ARGUMENTS_PATTERN.matcher(parameters);
+        Matcher inputParameterMatcherTwoArguments = TWO_ARGUMENTS_PATTERN.matcher(parameters);
 
         if (inputParameterMatcher.find()) {
             String text = inputParameterMatcher.group(FIRST_OPERATOR);
-            int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR));
+            int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR))-1;
             int end = Integer.parseInt(inputParameterMatcher.group(THIRD_OPERATOR));
 
-            if (start < 0)
-                start += text.length()+1;
-
-            if (end < 0)
-                end += text.length()+1 ;
-
-            verifyArguments(text, start-1, end);
-            return text.substring(start-1, end);
+            verifyArguments(text, start, end);
+            return text.substring(start, end);
 
         } else if (inputParameterMatcherTwoArguments.find()){
 
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
-            int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR));
+            int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR))-1;
 
-            if (start < 0)
-                start += text.length()+1;
-
-            verifyArguments(text, start-1);
-            return text.substring(start-1);
+            verifyArguments(text, start);
+            return text.substring(start);
 
         } else {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -50,11 +50,12 @@ public class TextSubstring implements DataInstruction {
         }
     }
 
-    public String substring(String string, int beginIndex, int endIndex){
+
+    public static String substring(String string, int beginIndex, int endIndex){
         return string.substring(beginIndex-1,endIndex);
     }
 
-    public String substring(String string, int beginIndex){
+    public static String substring(String string, int beginIndex){
         String s1 = string.substring(beginIndex-1);
         List<String> collect = new ArrayList<>();
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -3,12 +3,9 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+
 
 public class TextSubstring implements DataInstruction {
 
@@ -18,24 +15,49 @@ public class TextSubstring implements DataInstruction {
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
             "\\s*(?<" + SECOND_OPERATOR + ">-?\\d+)\\s*,\\s*(?<" + THIRD_OPERATOR + ">-?\\d+)\\s*");
 
+    private final Pattern INPUT_PARAMETER_PATTERN_TWO_ARGUMENTS = Pattern.compile("(?<" + FIRST_OPERATOR + ">.+)," +
+            "\\s*(?<" + SECOND_OPERATOR + ">-?\\d+)\\s*");
+
     @Override
     public String generateOutput(String parameters) {
         Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
-        if (!inputParameterMatcher.find()) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
-        } else {
+        Matcher inputParameterMatcherTwoArguments = INPUT_PARAMETER_PATTERN_TWO_ARGUMENTS.matcher(parameters);
+
+        if (inputParameterMatcher.find()) {
             String text = inputParameterMatcher.group(FIRST_OPERATOR);
             int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR));
             int end = Integer.parseInt(inputParameterMatcher.group(THIRD_OPERATOR));
-            if (start < 0) {
-                start = text.length() + start;
-            }
-            if (end < 0) {
-                end = text.length() + end;
-            }
-            verifyArguments(text, start, end);
-            return text.substring(start, end);
+
+            if(start==0)
+                start=1;
+
+            if (start < 0)
+                start += text.length()+1;
+
+            if (end < 0)
+                end += text.length()+1 ;
+
+            verifyArguments(text, start-1, end);
+            return text.substring(start-1, end);
+
+        } else if (inputParameterMatcherTwoArguments.find()){
+
+            String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
+            int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR));
+
+            if(start==0)
+                start=1;
+
+            if (start < 0)
+                start += text.length()+1;
+
+            verifyArguments(text, start-1);
+            return text.substring(start-1);
+
+        } else {
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         }
+
     }
 
     private void verifyArguments(String text, int start, int end) {
@@ -49,18 +71,11 @@ public class TextSubstring implements DataInstruction {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be greater than end {1}", start, end));
         }
     }
-
-
-    public String substring(String string, int beginIndex, int endIndex){
-            return string.substring(beginIndex-1,endIndex);
+    private void verifyArguments(String text, int start) {
+        if (start < 0) {
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be smaller than 0", start));
+        }
     }
-
-    public String substring(String string, int beginIndex){
-            return string.substring(beginIndex-1);
-    }
-
-
-
 
     @Override
     public String getKeyword() {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -52,7 +52,7 @@ public class TextSubstring implements DataInstruction {
 
 
     public String substring(String string, int beginIndex, int endIndex){
-        if (beginIndex < 0 || endIndex > string.length()) {
+        if (beginIndex <= 0 || endIndex > string.length()) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less than 0 and endIndex cannot be greater than string.length {1}", beginIndex, endIndex));
         }else{
             return string.substring(beginIndex-1,endIndex);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -28,9 +28,6 @@ public class TextSubstring implements DataInstruction {
             int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR));
             int end = Integer.parseInt(inputParameterMatcher.group(THIRD_OPERATOR));
 
-            if(start==0)
-                start=1;
-
             if (start < 0)
                 start += text.length()+1;
 
@@ -44,9 +41,6 @@ public class TextSubstring implements DataInstruction {
 
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
             int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR));
-
-            if(start==0)
-                start=1;
 
             if (start < 0)
                 start += text.length()+1;

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -53,7 +53,7 @@ public class TextSubstring implements DataInstruction {
 
     public String substring(String string, int beginIndex, int endIndex){
         if (beginIndex <= 0 || endIndex > string.length()) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less than 0 and endIndex cannot be greater than string.length {1}", beginIndex, endIndex));
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". begin {0} cannot be less or equals to 0 and endIndex cannot be greater than string.length {1}", beginIndex, endIndex));
         }else{
             return string.substring(beginIndex-1,endIndex);
         }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -28,6 +28,7 @@ public class TextSubstring implements DataInstruction {
             int start = Integer.parseInt(inputParameterMatcher.group(SECOND_OPERATOR))-1;
             int end = Integer.parseInt(inputParameterMatcher.group(THIRD_OPERATOR));
 
+            //if the user put a negative value, add length() and +1=> in order to take the 0 into account
             if (start < 0)
                 start += text.length()+1;
 
@@ -42,6 +43,7 @@ public class TextSubstring implements DataInstruction {
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
             int start = Integer.parseInt(inputParameterMatcherTwoArguments.group(SECOND_OPERATOR))-1;
 
+            //if the user put a negative value, add length() and +1=> in order to take the 0 into account
             if (start < 0)
                 start += text.length()+1;
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -56,7 +56,7 @@ public class TextSubstring implements DataInstruction {
 
     private void verifyArguments(String text, int start, int end) {
         if (start < 0) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be smaller than 0", start));
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be smaller or equal than 0", start));
         }
         if (end > text.length()) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". end {0} cannot be greater than length of the text {1}", end, text.length()));
@@ -67,7 +67,7 @@ public class TextSubstring implements DataInstruction {
     }
     private void verifyArguments(String text, int start) {
         if (start < 0) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be smaller than 0", start));
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ". start {0} cannot be smaller or equal than 0", start));
         }
     }
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstring.java
@@ -56,13 +56,7 @@ public class TextSubstring implements DataInstruction {
     }
 
     public String substring(String string, int beginIndex){
-            String s1 = string.substring(beginIndex-1);
-            List<String> collect;
-
-            collect = Arrays.asList(s1.split("\\b"))
-                    .stream().filter(s-> s.matches("\\w+"))
-                    .collect(Collectors.toList());
-            return collect.get(0);
+            return string.substring(beginIndex-1);
     }
 
 

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -41,4 +41,6 @@ class TextSubstringTest {
         TextSubstring textSubstring = new TextSubstring();
         assertEquals("tests", textSubstring.generateOutput("teststring, -10, -5"));
     }
+
+
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -42,5 +42,4 @@ class TextSubstringTest {
         assertEquals("tests", textSubstring.generateOutput("teststring, -10, -5"));
     }
 
-
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -3,6 +3,7 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TextSubstringTest {
 
@@ -33,13 +34,14 @@ class TextSubstringTest {
     @Test
     void substringNegativeArguments() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("sts", textSubstring.generateOutput("teststring, -8, -6"));
+        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -8, -6"));
     }
 
     @Test
     void substringNegativeArgumentsStartMin() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("tests", textSubstring.generateOutput("teststring, -10, -6"));
+        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -10, -6"));
+
     }
 
     @Test
@@ -58,6 +60,6 @@ class TextSubstringTest {
     @Test
     void substringTwoArgumentsNegativeArguments() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("ststring", textSubstring.generateOutput("teststring, -8"));
+        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -8"));
     }
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -13,19 +13,19 @@ class TextSubstringTest {
     }
 
     @Test
-    void subtringEndMax() {
+    void substringEndMax() {
         TextSubstring textSubstring = new TextSubstring();
         assertEquals("tring", textSubstring.generateOutput("teststring, 5, 10"));
     }
 
     @Test
-    void subtringStartMin() {
+    void substringStartMin() {
         TextSubstring textSubstring = new TextSubstring();
         assertEquals("tests", textSubstring.generateOutput("teststring, 0, 5"));
     }
 
     @Test
-    void subtringStartMinEndMax() {
+    void substringStartMinEndMax() {
         TextSubstring textSubstring = new TextSubstring();
         assertEquals("teststring", textSubstring.generateOutput("teststring, 0, 10"));
     }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -21,13 +21,13 @@ class TextSubstringTest {
     @Test
     void substringStartMin() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("tests", textSubstring.generateOutput("teststring, 0, 5"));
+        assertEquals("tests", textSubstring.generateOutput("teststring, 1, 5"));
     }
 
     @Test
     void substringStartMinEndMax() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("teststring", textSubstring.generateOutput("teststring, 0, 10"));
+        assertEquals("teststring", textSubstring.generateOutput("teststring, 1, 10"));
     }
 
     @Test
@@ -51,7 +51,7 @@ class TextSubstringTest {
     @Test
     void substringTwoArgumentsStartMin() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("teststring", textSubstring.generateOutput("teststring, 0"));
+        assertEquals("teststring", textSubstring.generateOutput("teststring, 1"));
     }
 
 

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -9,13 +9,13 @@ class TextSubstringTest {
     @Test
     void substring() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("tri", textSubstring.generateOutput("teststring, 5, 8"));
+        assertEquals("stri", textSubstring.generateOutput("teststring, 5, 8"));
     }
 
     @Test
     void substringEndMax() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("tring", textSubstring.generateOutput("teststring, 5, 10"));
+        assertEquals("string", textSubstring.generateOutput("teststring, 5, 10"));
     }
 
     @Test
@@ -33,13 +33,31 @@ class TextSubstringTest {
     @Test
     void substringNegativeArguments() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("sts", textSubstring.generateOutput("teststring, -8, -5"));
+        assertEquals("sts", textSubstring.generateOutput("teststring, -8, -6"));
     }
 
     @Test
     void substringNegativeArgumentsStartMin() {
         TextSubstring textSubstring = new TextSubstring();
-        assertEquals("tests", textSubstring.generateOutput("teststring, -10, -5"));
+        assertEquals("tests", textSubstring.generateOutput("teststring, -10, -6"));
     }
 
+    @Test
+    void substringTwoArguments() {
+        TextSubstring textSubstring = new TextSubstring();
+        assertEquals("string", textSubstring.generateOutput("teststring, 5"));
+    }
+
+    @Test
+    void substringTwoArgumentsStartMin() {
+        TextSubstring textSubstring = new TextSubstring();
+        assertEquals("teststring", textSubstring.generateOutput("teststring, 0"));
+    }
+
+
+    @Test
+    void substringTwoArgumentsNegativeArguments() {
+        TextSubstring textSubstring = new TextSubstring();
+        assertEquals("ststring", textSubstring.generateOutput("teststring, -8"));
+    }
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextSubstringTest.java
@@ -3,7 +3,6 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TextSubstringTest {
 
@@ -34,14 +33,13 @@ class TextSubstringTest {
     @Test
     void substringNegativeArguments() {
         TextSubstring textSubstring = new TextSubstring();
-        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -8, -6"));
+        assertEquals("sts", textSubstring.generateOutput("teststring, -8, -6"));
     }
 
     @Test
     void substringNegativeArgumentsStartMin() {
         TextSubstring textSubstring = new TextSubstring();
-        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -10, -6"));
-
+        assertEquals("tests", textSubstring.generateOutput("teststring, -10, -6"));
     }
 
     @Test
@@ -60,6 +58,7 @@ class TextSubstringTest {
     @Test
     void substringTwoArgumentsNegativeArguments() {
         TextSubstring textSubstring = new TextSubstring();
-        assertThrows(IllegalArgumentException.class, () -> textSubstring.generateOutput("teststring, -8"));
+        assertEquals("ststring", textSubstring.generateOutput("teststring, -8"));
     }
+
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When executing the text.substring I want to have to have two options:
1. I define both the start and end index
2. I only define the start index

When defining both start and end index (text.substring(\<string>, \<begin index>, \<end index>)) I want the following to happen:  
text.substring(John Doe, 1, 4)--> John

When defining only the start index (text.substring(\<string>, \<begin index>)) I want the following to happen:
text.substring(John Doe, 6)--> Doe

**Id**
ab1a36e
