### PR TITLE
Allow time.format to receive 3 parameters like date.format

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -5,6 +5,8 @@ import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,32 +16,60 @@ import java.util.regex.Pattern;
  */
 public class TimeFormat implements DataInstruction {
 
-    private final String ORIGINAL_TIME_REPRESENTATION_KEY = "OriginalDateRepresentation";
+    private final String ORIGINAL_TIME_REPRESENTATION = "OriginalTimeRepresentation";
 
-    private final String DESIRED_TIME_REPRESENTATION_KEY = "DesiredDateRepresentation";
+    private final String ORIGINAL_TIME_REPRESENTATION_FORMAT = "OriginalTimeRepresentationFormat";
+
+    private final String DESIRED_TIME_REPRESENTATION_FORMAT = "DesiredTimeRepresentationFormat";
 
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile(
-            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_KEY + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*,\\s*\"?(?<"
-                    + DESIRED_TIME_REPRESENTATION_KEY + ">[^\"]+)\"?\\s*");
+            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
+                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*" +
+                    ",\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*");
 
     private final SimpleDateFormat ORIGINAL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
         Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
+
         if (!inputParameterMatcher.find()) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
+
+
+            if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
+                return formatTime(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION), inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT), inputParameterMatcher.group(THIRD_PARAMETER));
+            } else {
+                return formatTime(inputParameterMatcher.group(FIRST_PARAMETER), inputParameterMatcher.group(SECOND_PARAMETER));
+            }
+
+
+
+
             try {
-                Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_KEY));
+                Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
                 SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                        inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_KEY));
+                        inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
                 return desiredDateRepresentation.format(originalDate);
             } catch (ParseException e) {
                 throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
-                        inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_KEY)));
+                        inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
             }
+
+
         }
+    }
+
+    private String formatTime(String originalTimeRepresentation, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
+
+                SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
+                        inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
+                return desiredDateRepresentation.format(originalDate);
+        //return LocalDate.parse(originalDate, ORIGINAL_DATE_FORMAT).format(DateTimeFormatter.ofPattern(targetedFormat));
+    }
+    private String formatTime(String originalTimeRepresentation, String originalTimeRepresentationFormat, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
+        return LocalDate.parse(originalDate, DateTimeFormatter.ofPattern(originalFormat)).format(DateTimeFormatter.ofPattern(targetedFormat));
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -14,20 +14,20 @@ import java.util.regex.Pattern;
  */
 public class TimeFormat implements DataInstruction {
 
-    private final String ORIGINAL_TIME_REPRESENTATION = "OriginalTimeRepresentation";
+    private final static String ORIGINAL_TIME_REPRESENTATION = "OriginalTimeRepresentation";
 
-    private final String ORIGINAL_TIME_REPRESENTATION_FORMAT = "OriginalTimeRepresentationFormat";
+    private final static String ORIGINAL_TIME_REPRESENTATION_FORMAT = "OriginalTimeRepresentationFormat";
 
-    private final String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
+    private final static String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
 
-    private final Pattern INPUT_PARAMETERS_PATTERN = Pattern.compile(
+    private final static Pattern INPUT_PARAMETERS_PATTERN = Pattern.compile(
             "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
                     "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\",]+)\"?\\s*)?"+
                     ",\\s*\"?(?<" +  DESIRED_TIME_REPRESENTATION + ">[^\"]+)\"?");
 
 
     //date format by default
-    private SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
@@ -45,11 +45,11 @@ public class TimeFormat implements DataInstruction {
 
     private String formatTime(SimpleDateFormat dateFormat,Matcher inputParameterMatcher) {
         try {
-            Date originalDate = dateFormat.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
+            Date dateFormatTargeted = dateFormat.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
             SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
                     inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
 
-            return desiredDateRepresentation.format(originalDate);
+            return desiredDateRepresentation.format(dateFormatTargeted);
         } catch (ParseException e) {
             throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
                     inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -21,8 +21,8 @@ public class TimeFormat implements DataInstruction {
     private final static String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
 
     private final static Pattern INPUT_PARAMETERS_PATTERN = Pattern.compile(
-            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
-                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\",]+)\"?\\s*)?"+
+            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">[^\"]+)\"?\\s*" +
+                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*)?"+
                     ",\\s*\"?(?<" +  DESIRED_TIME_REPRESENTATION + ">[^\"]+)\"?");
 
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -20,14 +20,14 @@ public class TimeFormat implements DataInstruction {
 
     private final String ORIGINAL_TIME_REPRESENTATION_FORMAT = "OriginalTimeRepresentationFormat";
 
-    private final String DESIRED_TIME_REPRESENTATION_FORMAT = "DesiredTimeRepresentationFormat";
+    private final String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
 
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile(
             "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
-                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION_FORMAT + ">[^\",]+)\"?\\s*" +
+                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION + ">[^\",]+)\"?\\s*" +
                     "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
 
-    private final SimpleDateFormat ORIGINAL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private SimpleDateFormat ORIGINAL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
@@ -37,10 +37,11 @@ public class TimeFormat implements DataInstruction {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
             if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
+                SimpleDateFormat CUSTOM_DATE_FORMAT = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT)) ;
                 try {
-                    Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
+                    Date originalDate = CUSTOM_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
                     SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
+                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
                     return desiredDateRepresentation.format(originalDate);
                 } catch (ParseException e) {
                     throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
@@ -51,7 +52,7 @@ public class TimeFormat implements DataInstruction {
                 try {
                     Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
                     SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
+                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
                     return desiredDateRepresentation.format(originalDate);
                 } catch (ParseException e) {
                     throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -27,7 +27,13 @@ public class TimeFormat implements DataInstruction {
                     ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION + ">[^\",]+)\"?\\s*" +
                     "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
 
-    private SimpleDateFormat ORIGINAL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private final Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile(
+            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
+                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION + ">[^\",]+)\"?\\s*" +
+                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
+
+    //date format by default
+    private SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
@@ -37,47 +43,26 @@ public class TimeFormat implements DataInstruction {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
             if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
-                SimpleDateFormat CUSTOM_DATE_FORMAT = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT)) ;
-                try {
-                    Date originalDate = CUSTOM_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
-                    SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
-                    return desiredDateRepresentation.format(originalDate);
-                } catch (ParseException e) {
-                    throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
-                            inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
-                }
-            } else {
-                System.out.println("ICI C 2 ARGUMENTS");
-                try {
-                    Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
-                    SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
-                    return desiredDateRepresentation.format(originalDate);
-                } catch (ParseException e) {
-                    throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
-                            inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
-                }
+                DATE_FORMAT = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
+
             }
-
-
-
-
-
+            return formatTime(DATE_FORMAT,inputParameterMatcher);
         }
     }
-/*
-    private String formatTime(String originalTimeRepresentation, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
 
-                SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                        inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
-                return desiredDateRepresentation.format(originalDate);
-        //return LocalDate.parse(originalDate, ORIGINAL_DATE_FORMAT).format(DateTimeFormatter.ofPattern(targetedFormat));
+    private String formatTime(SimpleDateFormat dateFormat,Matcher inputParameterMatcher) {
+        try {
+            Date originalDate = dateFormat.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
+            SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
+                    inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION));
+
+            return desiredDateRepresentation.format(originalDate);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
+                    inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
+        }
     }
-    private String formatTime(String originalTimeRepresentation, String originalTimeRepresentationFormat, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
-        return LocalDate.parse(originalDate, DateTimeFormatter.ofPattern(originalFormat)).format(DateTimeFormatter.ofPattern(targetedFormat));
-    }
-*/
+
     @Override
     public String getKeyword() {
         return "time.format";

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -5,8 +5,6 @@ import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,29 +20,24 @@ public class TimeFormat implements DataInstruction {
 
     private final String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
 
-    private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile(
+    private final Pattern INPUT_PARAMETERS_PATTERN = Pattern.compile(
             "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
-                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION + ">[^\",]+)\"?\\s*" +
-                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
+                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\",]+)\"?\\s*)?"+
+                    ",\\s*\"?(?<" +  DESIRED_TIME_REPRESENTATION + ">[^\"]+)\"?");
 
-    private final Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile(
-            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
-                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION + ">[^\",]+)\"?\\s*" +
-                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
 
     //date format by default
     private SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
-        Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
+        Matcher inputParameterMatcher = INPUT_PARAMETERS_PATTERN.matcher(parameters);
 
         if (!inputParameterMatcher.find()) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
             if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
                 DATE_FORMAT = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
-
             }
             return formatTime(DATE_FORMAT,inputParameterMatcher);
         }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -27,7 +27,7 @@ public class TimeFormat implements DataInstruction {
 
 
     //date format by default
-    private static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     @Override
     public String generateOutput(String parameters) {
@@ -37,7 +37,8 @@ public class TimeFormat implements DataInstruction {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
             if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
-                DATE_FORMAT = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
+             SimpleDateFormat  DATE_FORMAT_CUSTOM = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
+                return formatTime(DATE_FORMAT_CUSTOM,inputParameterMatcher);
             }
             return formatTime(DATE_FORMAT,inputParameterMatcher);
         }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -24,8 +24,8 @@ public class TimeFormat implements DataInstruction {
 
     private final Pattern INPUT_PARAMETER_PATTERN = Pattern.compile(
             "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})\"?\\s*" +
-                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*" +
-                    ",\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*");
+                    ",\\s*\"?(?<" + DESIRED_TIME_REPRESENTATION_FORMAT + ">[^\",]+)\"?\\s*" +
+                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?)?");
 
     private final SimpleDateFormat ORIGINAL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
@@ -36,31 +36,36 @@ public class TimeFormat implements DataInstruction {
         if (!inputParameterMatcher.find()) {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         } else {
-
-
             if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
-                return formatTime(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION), inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT), inputParameterMatcher.group(THIRD_PARAMETER));
+                try {
+                    Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
+                    SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
+                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
+                    return desiredDateRepresentation.format(originalDate);
+                } catch (ParseException e) {
+                    throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
+                            inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
+                }
             } else {
-                return formatTime(inputParameterMatcher.group(FIRST_PARAMETER), inputParameterMatcher.group(SECOND_PARAMETER));
+                System.out.println("ICI C 2 ARGUMENTS");
+                try {
+                    Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
+                    SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
+                            inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
+                    return desiredDateRepresentation.format(originalDate);
+                } catch (ParseException e) {
+                    throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
+                            inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
+                }
             }
 
 
 
-
-            try {
-                Date originalDate = ORIGINAL_DATE_FORMAT.parse(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION));
-                SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
-                        inputParameterMatcher.group(DESIRED_TIME_REPRESENTATION_FORMAT));
-                return desiredDateRepresentation.format(originalDate);
-            } catch (ParseException e) {
-                throw new IllegalArgumentException(MessageFormat.format("Cannot generate Time from {0}",
-                        inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION)));
-            }
 
 
         }
     }
-
+/*
     private String formatTime(String originalTimeRepresentation, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
 
                 SimpleDateFormat desiredDateRepresentation = new SimpleDateFormat(
@@ -71,7 +76,7 @@ public class TimeFormat implements DataInstruction {
     private String formatTime(String originalTimeRepresentation, String originalTimeRepresentationFormat, String desiredTimeRepresentation,Matcher inputParameterMatcher) {
         return LocalDate.parse(originalDate, DateTimeFormatter.ofPattern(originalFormat)).format(DateTimeFormatter.ofPattern(targetedFormat));
     }
-
+*/
     @Override
     public String getKeyword() {
         return "time.format";

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormat.java
@@ -20,9 +20,13 @@ public class TimeFormat implements DataInstruction {
 
     private final static String DESIRED_TIME_REPRESENTATION = "DesiredTimeRepresentation";
 
-    private final static Pattern INPUT_PARAMETERS_PATTERN = Pattern.compile(
-            "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">[^\"]+)\"?\\s*" +
-                    "(,\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*)?"+
+    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile(
+                    "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">[^\"]+)\"?\\s*" +
+                    ",\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION_FORMAT + ">[^\"]+)\"?\\s*"+
+                    ",\\s*\"?(?<" +  DESIRED_TIME_REPRESENTATION + ">[^\"]+)\"?");
+
+    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile(
+                    "\\s*\"?(?<" + ORIGINAL_TIME_REPRESENTATION + ">[^\"]+)\"?\\s*" +
                     ",\\s*\"?(?<" +  DESIRED_TIME_REPRESENTATION + ">[^\"]+)\"?");
 
 
@@ -31,17 +35,21 @@ public class TimeFormat implements DataInstruction {
 
     @Override
     public String generateOutput(String parameters) {
-        Matcher inputParameterMatcher = INPUT_PARAMETERS_PATTERN.matcher(parameters);
+        Matcher threeParameterMatcher = THREE_ARGUMENTS_PATTERN.matcher(parameters);
+        Matcher twoParameterMatcher = TWO_ARGUMENTS_PATTERN.matcher(parameters);
 
-        if (!inputParameterMatcher.find()) {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+        if(threeParameterMatcher.find()){
+
+            SimpleDateFormat  dateFormatCustom = new SimpleDateFormat(threeParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
+            return formatTime(dateFormatCustom,threeParameterMatcher);
+
+        } else if (twoParameterMatcher.find()){
+            return formatTime(DATE_FORMAT,twoParameterMatcher);
+
         } else {
-            if (inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT) != null) {
-             SimpleDateFormat  DATE_FORMAT_CUSTOM = new SimpleDateFormat(inputParameterMatcher.group(ORIGINAL_TIME_REPRESENTATION_FORMAT));
-                return formatTime(DATE_FORMAT_CUSTOM,inputParameterMatcher);
-            }
-            return formatTime(DATE_FORMAT,inputParameterMatcher);
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         }
+
     }
 
     private String formatTime(SimpleDateFormat dateFormat,Matcher inputParameterMatcher) {

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
@@ -30,8 +30,8 @@ class TimeFormatTest {
     @Test
     void generateOutputText() {
         TimeFormat timeFormat = new TimeFormat();
-        assertEquals("05 of 02 of 2000 12:12:12",
-                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"yyyy-MM-dd HH:mm:ss.SSS\", \"MM 'of' dd 'of' yyyy HH:mm:ss\""));
+        assertEquals("05/02/2000 12:12:12",
+                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"yyyy-MM-dd HH:mm:ss.SSS\", \"MM/dd/yyyy HH:mm:ss\""));
     }
 
     @Test

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
@@ -31,7 +31,14 @@ class TimeFormatTest {
     void generateOutputText() {
         TimeFormat timeFormat = new TimeFormat();
         assertEquals("05 of 02 of 2000 12:12:12",
-                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"MM 'of' dd 'of' yyyy HH:mm:ss\", \"yyyy-MM-dd HH:mm:ss.SSS\""));
+                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"yyyy-MM-dd HH:mm:ss.SSS\", \"MM 'of' dd 'of' yyyy HH:mm:ss\""));
+    }
+
+    @Test
+    void generateOutputText2() {
+        TimeFormat timeFormat = new TimeFormat();
+        assertEquals("02 of 05 of 2000 12:12:12",
+                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"yyyy-MM-dd HH:mm:ss.SSS\", \"dd 'of' MM 'of' yyyy HH:mm:ss\""));
     }
 
     @Test

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
@@ -31,7 +31,7 @@ class TimeFormatTest {
     void generateOutputText() {
         TimeFormat timeFormat = new TimeFormat();
         assertEquals("05 of 02 of 2000 12:12:12",
-                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"MM 'of' dd 'of' yyyy HH:mm:ss\""));
+                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"MM 'of' dd 'of' yyyy HH:mm:ss\", \"MM 'of' dd 'of' yyyy HH:mm:ss\""));
     }
 
     @Test

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
@@ -31,7 +31,7 @@ class TimeFormatTest {
     void generateOutputText() {
         TimeFormat timeFormat = new TimeFormat();
         assertEquals("05 of 02 of 2000 12:12:12",
-                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"MM 'of' dd 'of' yyyy HH:mm:ss\", \"MM 'of' dd 'of' yyyy HH:mm:ss\""));
+                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"MM 'of' dd 'of' yyyy HH:mm:ss\", \"yyyy-MM-dd HH:mm:ss.SSS\""));
     }
 
     @Test

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/time/TimeFormatTest.java
@@ -38,7 +38,7 @@ class TimeFormatTest {
     void generateOutputText2() {
         TimeFormat timeFormat = new TimeFormat();
         assertEquals("02 of 05 of 2000 12:12:12",
-                timeFormat.generateOutput("2000-05-02 12:12:12.121, \"yyyy-MM-dd HH:mm:ss.SSS\", \"dd 'of' MM 'of' yyyy HH:mm:ss\""));
+                timeFormat.generateOutput("05-02-2000 12:12:12, \"MM-dd-yyyy HH:mm:ss\", \"dd 'of' MM 'of' yyyy HH:mm:ss\""));
     }
 
     @Test


### PR DESCRIPTION
**Describe the bug**
When executing the time.format I want to have to have two options:

1. I define the original timestamp, the format of the original timestamp and the format of the desired timestamp
2. I define the original timestamp and the format of the desired timestamp. Here the original timestamp format is assumed to be 'yyyy-MM-dd HH:mm:ss.SSS'

**da4f2e3**

