### PR TITLE
Allow download of script configuration from API

### DIFF
--- a/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
+++ b/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
@@ -60,7 +60,7 @@ paths:
                   type: string
         '404':
           description: default response
-    
+
 
   '/script-executions':
     get:
@@ -242,7 +242,7 @@ paths:
                 $ref: '#/components/schemas/ConnectionTypeDto'
         '404':
           description: default response
- 
+
   '/components/{name}/{version}':
     get:
       tags:
@@ -449,7 +449,7 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
   '/components/{name}':
     get:
       tags:
@@ -609,7 +609,7 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
   '/connections':
     get:
       tags:
@@ -709,7 +709,7 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
   '/connections/{name}':
     get:
       tags:
@@ -765,7 +765,7 @@ paths:
                   type: string
         '404':
           description: default response
-    
+
   '/environments':
     get:
       tags:
@@ -865,7 +865,7 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
   '/environments/{name}':
     get:
       tags:
@@ -1128,7 +1128,7 @@ paths:
             See https://stackoverflow.com/questions/33018127/spring-data-rest-sort-by-multiple-properties for query parameter formatting. Sort the result set according to the provided keywords. The order of sorting follows the order of the list. By default sorting is applied in the ascending direction but this can be altered by explicitly providing the sorting direction:
              * `script[,desc|,asc]` - Sort by script name of script execution request.
              * `version[,desc|,asc]` - Sort by script version of script execution request.
-             * `request_timestamp[,desc|,asc]` - Sort by execution request timestamp. 
+             * `request_timestamp[,desc|,asc]` - Sort by execution request timestamp.
       operationId: getAll_3
       responses:
         '200':
@@ -1392,7 +1392,7 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
   '/scripts/{name}/{version}':
     get:
       tags:
@@ -1495,6 +1495,32 @@ paths:
                   type: string
         '404':
           description: default response
+  '/scripts/{name}/{version}/download':
+    get:
+      tags:
+        - scripts
+      operationId: get_file
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: JSON file got has response
+          content:
+            'OCTET_STREAM':
+              schema:
+                $ref: '#/components/schemas/ScriptGetDto'
+        '404':
+          description: default response
   /scripts:
     get:
       tags:
@@ -1546,7 +1572,7 @@ paths:
           explode: false
           description: >
             See https://stackoverflow.com/questions/33018127/spring-data-rest-sort-by-multiple-properties for query parameter formatting. Sort the result set according to the provided keywords. The order of sorting follows the order of the list. By default sorting is applied in the ascending direction but this can be altered by explicitly providing the sorting direction:
-             * `name[,desc|,asc]` - Sort by script name. 
+             * `name[,desc|,asc]` - Sort by script name.
       responses:
         '200':
           description: default response
@@ -1699,10 +1725,10 @@ paths:
                   type: string
         '404':
           description: default response
-  
+
 components:
   parameters:
-    paginationPageParameter: 
+    paginationPageParameter:
       in: query
       name: page
       required: false
@@ -1722,7 +1748,7 @@ components:
       description: The numbers of items to return.
 
   schemas:
-  
+
     ComponentAttributeDto:
       type: object
       properties:
@@ -1791,7 +1817,7 @@ components:
       properties:
         href:
           type: string
-        
+
     HalMultipleEmbeddedResourceComponentDto:
       type: object
       properties:
@@ -2102,7 +2128,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Link'
-            
+
     ExecutionRequestPostDto:
       type: object
       properties:
@@ -2472,16 +2498,16 @@ components:
     PaginationProperties:
       type: object
       properties:
-        size: 
+        size:
           type: integer
           description: Number of element displayed on the page
-        totalElements: 
+        totalElements:
           type: integer
           description: Number of element Avalaible in the API through this endpoint
-        totalPages: 
+        totalPages:
           type: integer
           description: Number of page with the parameter size and totalElements
-        number: 
+        number:
           type: integer
           description: Actual Number of the page (starts from 1 to n)
 
@@ -2510,21 +2536,21 @@ components:
     ScriptExecutionDto:
       type: object
       properties:
-        runId: 
+        runId:
           type: string
-        processId: 
+        processId:
           type: string
-        parentProcessId: 
+        parentProcessId:
           type: number
-        scriptId: 
+        scriptId:
           type: string
-        scriptName: 
+        scriptName:
           type: string
-        scriptVersion: 
+        scriptVersion:
           type: number
-        environment: 
+        environment:
           type: string
-        status: 
+        status:
           type: string
           enum:
             - RUNNING
@@ -2533,10 +2559,10 @@ components:
             - ERROR
             - STOPPED
             - SKIPPED
-        startTimestamp: 
+        startTimestamp:
           type: string
           format: date-time
-        endTimestamp: 
+        endTimestamp:
           type: string
           format: date-time
         inputParameters:
@@ -2568,38 +2594,38 @@ components:
     InputParameter:
       type: object
       properties:
-        name: 
+        name:
           type: string
-        rawValue: 
+        rawValue:
           type: string
-        resolvedValue: 
+        resolvedValue:
           type: string
 
     ActionResult:
       type: object
       properties:
-        runId: 
+        runId:
           type: string
-        processId: 
+        processId:
           type: number
-        type: 
+        type:
           type: string
-        name: 
+        name:
           type: string
-        description: 
+        description:
           type: string
-        condition: 
+        condition:
           type: string
-        errorStop: 
+        errorStop:
           type: boolean
-        errorExpected: 
+        errorExpected:
           type: boolean
-        status: 
+        status:
           type: string
-        startTimestamp: 
+        startTimestamp:
           type: string
           format: date-time
-        endTimestamp: 
+        endTimestamp:
           type: string
           format: date-time
         inputParameters:
@@ -2660,7 +2686,7 @@ components:
               $ref: '#/components/schemas/Link'
             scriptResultsOfThisRunId:
               $ref: '#/components/schemas/Link'
-    
+
     ScriptGetDto:
       type: object
       properties:
@@ -2736,7 +2762,7 @@ components:
           type: string
         expiresIn:
           type: number
-            
+
 
 
   securitySchemes:

--- a/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
+++ b/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
@@ -1495,6 +1495,32 @@ paths:
                   type: string
         '404':
           description: default response
+  '/scripts/{name}/{version}/download':
+    get:
+      tags:
+        - scripts
+      operationId: get_file
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: JSON file got has response
+          content:
+            'OCTET_STREAM':
+              schema:
+                $ref: '#/components/schemas/ScriptGetDto'
+        '404':
+          description: default response
   /scripts:
     get:
       tags:

--- a/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
+++ b/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
@@ -1495,32 +1495,6 @@ paths:
                   type: string
         '404':
           description: default response
-  '/scripts/{name}/{version}/download':
-    get:
-      tags:
-        - scripts
-      operationId: get_file
-      parameters:
-        - name: name
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: version
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: JSON file got has response
-          content:
-            'OCTET_STREAM':
-              schema:
-                $ref: '#/components/schemas/ScriptGetDto'
-        '404':
-          description: default response
   /scripts:
     get:
       tags:

--- a/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
+++ b/core/java/iesi-rest-without-microservices/docs/iesi-openapi.yaml
@@ -1514,7 +1514,7 @@ paths:
             format: int64
       responses:
         '200':
-          description: JSON file got has response
+          description: script content got as JSON file response
           content:
             'OCTET_STREAM':
               schema:

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -9,16 +9,24 @@ import io.metadew.iesi.server.rest.resource.HalMultipleEmbeddedResource;
 import io.metadew.iesi.server.rest.script.dto.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -100,7 +108,30 @@ public class ScriptController {
                          @RequestParam(required = false, name = "expand", defaultValue = "") List<String> expansions) throws MetadataDoesNotExistException {
         ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version, expansions)
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
+
         return scriptDtoModelAssembler.toModel(scriptDto);
+    }
+
+    @GetMapping("/{name}/{version}/download")
+    public ResponseEntity<Resource> getJsonFile(@PathVariable String name,
+                                                @PathVariable Long version,
+                                                @RequestParam(required = false, name = "expand", defaultValue = "") List<String> expansions) throws MetadataDoesNotExistException, IOException {
+
+        ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version, expansions)
+                .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
+
+
+        ByteArrayResource resource = new ByteArrayResource();
+
+      //  InputStreamResource resource1 = new InputStreamResource();
+
+        return ResponseEntity.ok()
+              //  .headers(headers)
+                .contentLength(file.length())
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
+
+       // return scriptDtoModelAssembler.toModel(scriptDto);
     }
 
     @PostMapping("")

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -1,7 +1,6 @@
 package io.metadew.iesi.server.rest.script;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.jsonschema.JsonSerializableSchema;
+
 import io.metadew.iesi.metadata.configuration.exception.MetadataAlreadyExistsException;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
 import io.metadew.iesi.metadata.definition.script.Script;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -9,7 +9,6 @@ import io.metadew.iesi.metadata.tools.IdentifierTools;
 import io.metadew.iesi.server.rest.error.DataBadRequestException;
 import io.metadew.iesi.server.rest.resource.HalMultipleEmbeddedResource;
 import io.metadew.iesi.server.rest.script.dto.*;
-import io.metadew.iesi.server.rest.script.dto.version.ScriptVersionDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -119,7 +119,7 @@ public class ScriptController {
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
 
         ContentDisposition contentDisposition = ContentDisposition.builder("inline")
-                .filename(String.format("%s-%d.json",name,version))
+                .filename(String.format("script_%s_%d.json",name,version))
                 .build();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentDisposition(contentDisposition);

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -9,7 +9,6 @@ import io.metadew.iesi.metadata.tools.IdentifierTools;
 import io.metadew.iesi.server.rest.error.DataBadRequestException;
 import io.metadew.iesi.server.rest.resource.HalMultipleEmbeddedResource;
 import io.metadew.iesi.server.rest.script.dto.*;
-import io.metadew.iesi.server.rest.script.dto.version.ScriptVersionDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -124,7 +123,6 @@ public class ScriptController {
                 .build();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentDisposition(contentDisposition);
-
 
         String jsonString = objectMapper.writeValueAsString(scriptDto);
 

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -115,7 +115,7 @@ public class ScriptController {
 
     @GetMapping("/{name}/{version}/download")
     public ResponseEntity<Resource> getFile(@PathVariable String name,
-                                                @PathVariable Long version) throws MetadataDoesNotExistException, IOException {
+                                                @PathVariable Long version) throws IOException {
 
         ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version,new ArrayList<>())
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -9,6 +9,7 @@ import io.metadew.iesi.metadata.tools.IdentifierTools;
 import io.metadew.iesi.server.rest.error.DataBadRequestException;
 import io.metadew.iesi.server.rest.resource.HalMultipleEmbeddedResource;
 import io.metadew.iesi.server.rest.script.dto.*;
+import io.metadew.iesi.server.rest.script.dto.version.ScriptVersionDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -120,10 +121,9 @@ public class ScriptController {
         ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version,new ArrayList<>())
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
 
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        objectMapper.writeValue((OutputStream) new ObjectOutputStream(bos),scriptDto);
+        String jsonString = objectMapper.writeValueAsString(scriptDto);
 
-        byte [] data = bos.toByteArray();
+        byte [] data = jsonString.getBytes();
         ByteArrayResource resource = new ByteArrayResource(data);
 
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM).body(resource);

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -9,6 +9,7 @@ import io.metadew.iesi.metadata.tools.IdentifierTools;
 import io.metadew.iesi.server.rest.error.DataBadRequestException;
 import io.metadew.iesi.server.rest.resource.HalMultipleEmbeddedResource;
 import io.metadew.iesi.server.rest.script.dto.*;
+import io.metadew.iesi.server.rest.script.dto.version.ScriptVersionDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -18,9 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -120,12 +119,19 @@ public class ScriptController {
         ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version,new ArrayList<>())
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
 
+        ContentDisposition contentDisposition = ContentDisposition.builder("inline")
+                .filename(String.format("%s-%d.json",name,version))
+                .build();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentDisposition(contentDisposition);
+
+
         String jsonString = objectMapper.writeValueAsString(scriptDto);
 
         byte [] data = jsonString.getBytes();
         ByteArrayResource resource = new ByteArrayResource(data);
 
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM).body(resource);
+        return ResponseEntity.ok().headers(httpHeaders).contentType(MediaType.APPLICATION_OCTET_STREAM).body(resource);
 
     }
 

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/ScriptController.java
@@ -117,7 +117,7 @@ public class ScriptController {
     public ResponseEntity<Resource> getFile(@PathVariable String name,
                                                 @PathVariable Long version) throws MetadataDoesNotExistException, IOException {
 
-        ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version,null)
+        ScriptDto scriptDto = scriptDtoService.getByNameAndVersion(name, version,new ArrayList<>())
                 .orElseThrow(() -> new MetadataDoesNotExistException(new ScriptKey(IdentifierTools.getScriptIdentifier(name), version)));
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDto.java
@@ -12,6 +12,8 @@ import lombok.*;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.core.Relation;
 
+
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -21,7 +23,7 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Relation(value = "script", collectionRelation = "scripts")
-public class ScriptDto extends RepresentationModel<ScriptDto> {
+public class ScriptDto extends RepresentationModel<ScriptDto> implements Serializable {
 
     private String name;
     private String description;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDto.java
@@ -13,7 +13,6 @@ import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.core.Relation;
 
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,7 +22,7 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Relation(value = "script", collectionRelation = "scripts")
-public class ScriptDto extends RepresentationModel<ScriptDto> implements Serializable {
+public class ScriptDto extends RepresentationModel<ScriptDto>  {
 
     private String name;
     private String description;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
@@ -6,13 +6,30 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.hateoas.RepresentationModel;
 
+import java.io.Serializable;
+
 @Data
 @EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
-public class ScriptVersionDto extends RepresentationModel<ScriptVersionDto> {
+public class ScriptVersionDto extends RepresentationModel<ScriptVersionDto> implements Serializable {
 
     private long number;
     private String description;
 
+    public long getNumber() {
+        return number;
+    }
+
+    public void setNumber(long number) {
+        this.number = number;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
@@ -6,13 +6,12 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.hateoas.RepresentationModel;
 
-import java.io.Serializable;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
-public class ScriptVersionDto extends RepresentationModel<ScriptVersionDto> implements Serializable {
+public class ScriptVersionDto extends RepresentationModel<ScriptVersionDto> {
 
     private long number;
     private String description;

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/version/ScriptVersionDto.java
@@ -16,19 +16,4 @@ public class ScriptVersionDto extends RepresentationModel<ScriptVersionDto> {
     private long number;
     private String description;
 
-    public long getNumber() {
-        return number;
-    }
-
-    public void setNumber(long number) {
-        this.number = number;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
 }

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
@@ -712,10 +712,41 @@ class ScriptControllerTest {
         Optional<ScriptDto> optionalScriptDto = Optional.of(ScriptDtoBuilder.simpleScriptDto("nameTest", 0));
         given(scriptDtoService.getByNameAndVersion("nameTest", 0, new ArrayList<>())).willReturn(optionalScriptDto);
 
+
         mvc.perform(get("/scripts/nameTest/0/download"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM));
+                .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
+                .andExpect(jsonPath("$.name", is("nameTest")))
+                .andExpect(jsonPath("$.description").exists())
+                .andExpect(jsonPath("$.version.number").exists())
+                .andExpect(jsonPath("$.version.description").exists())
+                .andExpect(jsonPath("$.parameters").exists())
+                .andExpect(jsonPath("$.parameters[0].name").exists())
+                .andExpect(jsonPath("$.parameters[0].value").exists())
+                .andExpect(jsonPath("$.parameters[1].name").exists())
+                .andExpect(jsonPath("$.parameters[1].value").exists())
+                .andExpect(jsonPath("$.actions").exists())
+                .andExpect(jsonPath("$.actions[0].number").exists())
+                .andExpect(jsonPath("$.actions[0].name").exists())
+                .andExpect(jsonPath("$.actions[0].type").exists())
+                .andExpect(jsonPath("$.actions[0].description").exists())
+                .andExpect(jsonPath("$.actions[0].component").exists())
+                .andExpect(jsonPath("$.actions[0].condition").exists())
+                .andExpect(jsonPath("$.actions[0].iteration").exists())
+                .andExpect(jsonPath("$.actions[0].errorExpected").exists())
+                .andExpect(jsonPath("$.actions[0].errorStop").exists())
+                .andExpect(jsonPath("$.actions[0].retries").exists())
+                .andExpect(jsonPath("$.actions[0].parameters[0].name").exists())
+                .andExpect(jsonPath("$.actions[0].parameters[0].value").exists())
+                .andExpect(jsonPath("$.actions[0].parameters[1].name").exists())
+                .andExpect(jsonPath("$.actions[0].parameters[1].value").exists())
+                .andExpect(jsonPath("$.labels[0].name").exists())
+                .andExpect(jsonPath("$.labels[0].value").exists())
+                .andExpect(jsonPath("$.labels[1].name").exists())
+                .andExpect(jsonPath("$.labels[1].value").exists());
+
     }
+
 
     @Test
     void getByNameAndVersionFileDoesNotExist() throws Exception {

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
@@ -710,11 +710,21 @@ class ScriptControllerTest {
     void getByNameAndVersionFile() throws Exception {
         // Mock Service
         Optional<ScriptDto> optionalScriptDto = Optional.of(ScriptDtoBuilder.simpleScriptDto("nameTest", 0));
-        given(scriptDtoService.getByNameAndVersion("nameTest", 0, null)).willReturn(optionalScriptDto);
+        given(scriptDtoService.getByNameAndVersion("nameTest", 0, new ArrayList<>())).willReturn(optionalScriptDto);
 
         mvc.perform(get("/scripts/nameTest/0/download"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM));
+    }
+
+    @Test
+    void getByNameAndVersionFileDoesNotExist() throws Exception {
+
+        Optional<ScriptDto> optionalScriptDto = Optional.of(ScriptDtoBuilder.simpleScriptDto("nameTest", 0));
+        given(scriptDtoService.getByNameAndVersion("nameTest", 0, new ArrayList<>())).willReturn(optionalScriptDto);
+
+        mvc.perform(get("/scripts/nameTest/1/download"))
+                .andExpect(status().isNotFound());
     }
 
 //    @Test

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
@@ -30,8 +30,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 //@RunWith(SpringRunner.class)
 @WebMvcTest(ScriptController.class)
@@ -713,8 +712,9 @@ class ScriptControllerTest {
         Optional<ScriptDto> optionalScriptDto = Optional.of(ScriptDtoBuilder.simpleScriptDto("nameTest", 0));
         given(scriptDtoService.getByNameAndVersion("nameTest", 0, null)).willReturn(optionalScriptDto);
 
-        mvc.perform(get("/scripts/nameTest/0/download").contentType(MediaType.APPLICATION_OCTET_STREAM))
-                .andExpect(status().isOk());
+        mvc.perform(get("/scripts/nameTest/0/download"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM));
     }
 
 //    @Test

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
@@ -707,6 +707,16 @@ class ScriptControllerTest {
                 .andExpect(status().isNotFound());
     }
 
+    @Test
+    void getByNameAndVersionFile() throws Exception {
+        // Mock Service
+        Optional<ScriptDto> optionalScriptDto = Optional.of(ScriptDtoBuilder.simpleScriptDto("nameTest", 0));
+        given(scriptDtoService.getByNameAndVersion("nameTest", 0, null)).willReturn(optionalScriptDto);
+
+        mvc.perform(get("/scripts/nameTest/0/download").contentType(MediaType.APPLICATION_OCTET_STREAM))
+                .andExpect(status().isNotFound());
+    }
+
 //    @Test
 //    void getByNameAndVersionSerializationTest() {
 //        // Todo: Write Test : use getByNameAndVersion400AndPropertyPresenceCheck and replace "jsonPath(x).exist()" by "jsonPath(x, is(y))"

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/script/ScriptControllerTest.java
@@ -714,7 +714,7 @@ class ScriptControllerTest {
         given(scriptDtoService.getByNameAndVersion("nameTest", 0, null)).willReturn(optionalScriptDto);
 
         mvc.perform(get("/scripts/nameTest/0/download").contentType(MediaType.APPLICATION_OCTET_STREAM))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isOk());
     }
 
 //    @Test


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I want to be able to download the raw JSON representation of a script by targeting a specific endpoint.

endpoint: GET /scripts/\<name>/\<version>
headers: Accept application/octet-stream

**Id**
7ef3cff
