### PR TITLE
http.executeRequest should update output dataset for override

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/tools/FolderTools.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/tools/FolderTools.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class FolderTools {
 
     public static File[] getFilesInFolder(String folderName, String filterType, String filterExpression) {
-        File[] files = null;
+        File[] files;
 
         if (filterType.equalsIgnoreCase("all")) {
             files = getAllFilesInFolder(folderName);
@@ -24,6 +24,8 @@ public final class FolderTools {
             files = getFilesInFolderUsingMatch(folderName, filterExpression);
         } else if (filterType.equalsIgnoreCase("regex")) {
             files = getFilesInFolderUsingRegex(folderName, filterExpression);
+        } else {
+            files = new File[0];
         }
 
         return files;
@@ -112,14 +114,9 @@ public final class FolderTools {
         final File folder = new File(folderName);
 
         final String fileFilter = filterExpression;
-        final File[] files = folder.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return name.matches(fileFilter);
-            }
-        });
 
-        return files;
+        File[] files = folder.listFiles((dir, name) -> name.matches(fileFilter));
+        return files == null ? new File[0] : files;
     }
 
     private static File[] getFilesInFolderUsingMatch(String folderName, String filterExpression) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/keyvalue/KeyValueDatasetService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/keyvalue/KeyValueDatasetService.java
@@ -70,7 +70,7 @@ public class KeyValueDatasetService extends DatasetService<KeyValueDataset> impl
             crs.next();
             int count = Integer.parseInt(crs.getString("ROW_COUNT"));
             crs.close();
-            return count > 0;
+            return count == 0;
         } catch (SQLException e) {
             throw new RuntimeException(String.format("Unable to check if dataset %s contains data items", keyValueDataset));
         }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/keyvalue/KeyValueDatasetService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/keyvalue/KeyValueDatasetService.java
@@ -60,6 +60,22 @@ public class KeyValueDatasetService extends DatasetService<KeyValueDataset> impl
     private KeyValueDatasetService() {
     }
 
+    public boolean isEmpty(KeyValueDataset keyValueDataset) {
+        String query = "select count(*) as row_count from " + SQLTools.GetStringForSQLTable(keyValueDataset.getTableName()) + ";";
+        CachedRowSet crs = DatabaseHandler.getInstance().executeQuery(keyValueDataset.getDatasetDatabase(), query);
+        if (crs.size() == 0) {
+            throw new RuntimeException(String.format("Unable to check if dataset %s contains data items", keyValueDataset));
+        }
+        try {
+            crs.next();
+            int count = Integer.parseInt(crs.getString("ROW_COUNT"));
+            crs.close();
+            return count > 0;
+        } catch (SQLException e) {
+            throw new RuntimeException(String.format("Unable to check if dataset %s contains data items", keyValueDataset));
+        }
+    }
+
     public KeyValueDataset getByNameAndLabels(String name, List<String> labels, ExecutionRuntime executionRuntime) {
         name = executionRuntime.resolveVariables(name);
         labels = labels.stream()

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/metadata/DatasetMetadata.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/metadata/DatasetMetadata.java
@@ -1,14 +1,11 @@
 package io.metadew.iesi.datatypes.dataset.metadata;
 
-import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.framework.FrameworkConfiguration;
 import io.metadew.iesi.connection.database.Database;
 import io.metadew.iesi.connection.database.sqlite.SqliteDatabase;
 import io.metadew.iesi.connection.database.sqlite.SqliteDatabaseConnection;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-
-import java.nio.file.Path;
 
 @Getter
 @EqualsAndHashCode
@@ -19,12 +16,6 @@ public class DatasetMetadata {
 
     public DatasetMetadata(String datasetName) {
         this.datasetName = datasetName;
-
-        String path1 = (String) Configuration.getInstance()
-                .getMandatoryProperty("iesi.home");
-
-        Path path2 = FrameworkConfiguration.getInstance()
-                .getMandatoryFrameworkFolder("data").getAbsolutePath();
         this.database = new SqliteDatabase(new SqliteDatabaseConnection(
                 FrameworkConfiguration.getInstance()
                         .getMandatoryFrameworkFolder("data").getAbsolutePath()

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/metadata/DatasetMetadata.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/metadata/DatasetMetadata.java
@@ -1,11 +1,14 @@
 package io.metadew.iesi.datatypes.dataset.metadata;
 
+import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.framework.FrameworkConfiguration;
 import io.metadew.iesi.connection.database.Database;
 import io.metadew.iesi.connection.database.sqlite.SqliteDatabase;
 import io.metadew.iesi.connection.database.sqlite.SqliteDatabaseConnection;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+
+import java.nio.file.Path;
 
 @Getter
 @EqualsAndHashCode
@@ -16,6 +19,12 @@ public class DatasetMetadata {
 
     public DatasetMetadata(String datasetName) {
         this.datasetName = datasetName;
+
+        String path1 = (String) Configuration.getInstance()
+                .getMandatoryProperty("iesi.home");
+
+        Path path2 = FrameworkConfiguration.getInstance()
+                .getMandatoryFrameworkFolder("data").getAbsolutePath();
         this.database = new SqliteDatabase(new SqliteDatabaseConnection(
                 FrameworkConfiguration.getInstance()
                         .getMandatoryFrameworkFolder("data").getAbsolutePath()

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -179,7 +179,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     private void outputResponse(HttpResponse httpResponse) throws IOException {
         Optional<KeyValueDataset> outputDataset = getOutputDataset();
         if (outputDataset.isPresent()) {
-            if (KeyValueDatasetService.getInstance().isEmpty(outputDataset.get())) {
+            if (!KeyValueDatasetService.getInstance().isEmpty(outputDataset.get())) {
                 log.warn(String.format("Output dataset %s already contains data items. Clearing old data items before writing output", outputDataset.get()));
                 KeyValueDatasetService.getInstance().clean(outputDataset.get(), getExecutionControl().getExecutionRuntime());
             }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -10,6 +10,7 @@ import io.metadew.iesi.connection.http.response.HttpResponseService;
 import io.metadew.iesi.datatypes.DataType;
 import io.metadew.iesi.datatypes.array.Array;
 import io.metadew.iesi.datatypes.dataset.keyvalue.KeyValueDataset;
+import io.metadew.iesi.datatypes.dataset.keyvalue.KeyValueDatasetService;
 import io.metadew.iesi.datatypes.text.Text;
 import io.metadew.iesi.metadata.configuration.connection.ConnectionConfiguration;
 import io.metadew.iesi.metadata.configuration.exception.MetadataDoesNotExistException;
@@ -21,9 +22,8 @@ import io.metadew.iesi.script.execution.ActionPerformanceLogger;
 import io.metadew.iesi.script.execution.ExecutionControl;
 import io.metadew.iesi.script.execution.ScriptExecution;
 import io.metadew.iesi.script.operation.ActionParameterOperation;
+import lombok.extern.log4j.Log4j2;
 import org.apache.http.Header;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -37,28 +37,27 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
+@Log4j2
 public class HttpExecuteRequest extends ActionTypeExecution {
 
-    private static Logger LOGGER = LogManager.getLogger();
-    // Parameters
-    private static final String requestKey = "request";
-    private static final String bodyKey = "body";
-    private static final String proxyKey = "proxy";
-    private static final String setDatasetKey = "setDataset";
-    private static final String expectedStatusCodesKey = "expectedStatusCodes";
+    private static final String REQUEST_KEY = "request";
+    private static final String BODY_KEY = "body";
+    private static final String PROXY_KEY = "proxy";
+    private static final String SET_DATASET_KEY = "setDataset";
+    private static final String EXPECTED_STATUS_CODES_KEY = "expectedStatusCodes";
 
     private HttpRequest httpRequest;
     private KeyValueDataset outputDataset;
     private ProxyConnection proxyConnection;
     private List<String> expectedStatusCodes;
 
-    private final Pattern INFORMATION_STATUS_CODE = Pattern.compile("1\\d\\d");
-    private final Pattern SUCCESS_STATUS_CODE = Pattern.compile("2\\d\\d");
-    private final Pattern REDIRECT_STATUS_CODE = Pattern.compile("3\\d\\d");
+    private static final Pattern INFORMATION_STATUS_CODE = Pattern.compile("1\\d\\d");
+    private static final Pattern SUCCESS_STATUS_CODE = Pattern.compile("2\\d\\d");
+    private static final Pattern REDIRECT_STATUS_CODE = Pattern.compile("3\\d\\d");
     @SuppressWarnings("unused")
-    private final Pattern SERVER_ERROR_STATUS_CODE = Pattern.compile("4\\d\\d");
+    private static final Pattern SERVER_ERROR_STATUS_CODE = Pattern.compile("4\\d\\d");
     @SuppressWarnings("unused")
-    private final Pattern CLIENT_ERROR_STATUS_CODE = Pattern.compile("5\\d\\d");
+    private static final Pattern CLIENT_ERROR_STATUS_CODE = Pattern.compile("5\\d\\d");
 
     public HttpExecuteRequest(ExecutionControl executionControl,
                               ScriptExecution scriptExecution, ActionExecution actionExecution) {
@@ -67,60 +66,56 @@ public class HttpExecuteRequest extends ActionTypeExecution {
 
     public void prepare() throws URISyntaxException, HttpRequestBuilderException, IOException, MetadataDoesNotExistException {
         // Reset Parameters
-        ActionParameterOperation requestNameActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), requestKey);
-        ActionParameterOperation requestBodyActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), bodyKey);
-        ActionParameterOperation setDatasetActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), setDatasetKey);
-        ActionParameterOperation expectedStatusCodesActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), expectedStatusCodesKey);
-        ActionParameterOperation proxyActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), proxyKey);
+        ActionParameterOperation requestNameActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), REQUEST_KEY);
+        ActionParameterOperation requestBodyActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), BODY_KEY);
+        ActionParameterOperation setDatasetActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), SET_DATASET_KEY);
+        ActionParameterOperation expectedStatusCodesActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), EXPECTED_STATUS_CODES_KEY);
+        ActionParameterOperation proxyActionParameterOperation = new ActionParameterOperation(getExecutionControl(), getActionExecution(), getActionExecution().getAction().getType(), PROXY_KEY);
 
         // Get Parameters
         for (ActionParameter actionParameter : getActionExecution().getAction().getParameters()) {
-            if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(requestKey)) {
+            if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(REQUEST_KEY)) {
                 requestNameActionParameterOperation.setInputValue(actionParameter.getValue(), getExecutionControl().getExecutionRuntime());
-            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(bodyKey)) {
+            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(BODY_KEY)) {
                 requestBodyActionParameterOperation.setInputValue(actionParameter.getValue(), getExecutionControl().getExecutionRuntime());
-            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(setDatasetKey)) {
+            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(SET_DATASET_KEY)) {
                 setDatasetActionParameterOperation.setInputValue(actionParameter.getValue(), getExecutionControl().getExecutionRuntime());
-            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(expectedStatusCodesKey)) {
+            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(EXPECTED_STATUS_CODES_KEY)) {
                 expectedStatusCodesActionParameterOperation.setInputValue(actionParameter.getValue(), getExecutionControl().getExecutionRuntime());
-            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(proxyKey)) {
+            } else if (actionParameter.getMetadataKey().getParameterName().equalsIgnoreCase(PROXY_KEY)) {
                 proxyActionParameterOperation.setInputValue(actionParameter.getValue(), getExecutionControl().getExecutionRuntime());
             }
         }
 
         // Create parameter list
-        getActionParameterOperationMap().put(requestKey, requestNameActionParameterOperation);
-        getActionParameterOperationMap().put(bodyKey, requestBodyActionParameterOperation);
-        getActionParameterOperationMap().put(setDatasetKey, setDatasetActionParameterOperation);
-        getActionParameterOperationMap().put(expectedStatusCodesKey, expectedStatusCodesActionParameterOperation);
-        getActionParameterOperationMap().put(proxyKey, proxyActionParameterOperation);
+        getActionParameterOperationMap().put(REQUEST_KEY, requestNameActionParameterOperation);
+        getActionParameterOperationMap().put(BODY_KEY, requestBodyActionParameterOperation);
+        getActionParameterOperationMap().put(SET_DATASET_KEY, setDatasetActionParameterOperation);
+        getActionParameterOperationMap().put(EXPECTED_STATUS_CODES_KEY, expectedStatusCodesActionParameterOperation);
+        getActionParameterOperationMap().put(PROXY_KEY, proxyActionParameterOperation);
 
-        if (convertHttpRequestBody(requestBodyActionParameterOperation.getValue()).isPresent()) {
-            convertHttpRequestBody(requestBodyActionParameterOperation.getValue())
-                    .ifPresent(body -> getActionExecution().getActionControl().logOutput("request.body", body));
+        Optional<String> body = convertHttpRequestBody(requestBodyActionParameterOperation.getValue());
+
+        if (body.isPresent()) {
+            getActionExecution().getActionControl().logOutput("request.body", body.get());
             httpRequest = HttpComponentService.getInstance().buildHttpRequest(
-                    HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(requestNameActionParameterOperation.getValue()), getActionExecution(), requestKey),
-                    convertHttpRequestBody(requestBodyActionParameterOperation.getValue()).get());
+                    HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(requestNameActionParameterOperation.getValue()), getActionExecution(), REQUEST_KEY),
+                    body.get());
         } else {
             httpRequest = HttpComponentService.getInstance().buildHttpRequest(
-                    HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(requestNameActionParameterOperation.getValue()), getActionExecution(), requestKey));
+                    HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(requestNameActionParameterOperation.getValue()), getActionExecution(), REQUEST_KEY));
         }
         getActionExecution().getActionControl().logOutput("request.uri", httpRequest.getHttpRequest().getURI().toString());
+        getActionExecution().getActionControl().logOutput("request.method", httpRequest.getHttpRequest().getMethod());
 
         for (int i = 0; i < httpRequest.getHttpRequest().getAllHeaders().length; i++) {
             Header header = httpRequest.getHttpRequest().getAllHeaders()[i];
             getActionExecution().getActionControl().logOutput("request.header." + i, header.toString());
         }
 
-
         expectedStatusCodes = convertExpectStatusCodes(expectedStatusCodesActionParameterOperation.getValue());
         proxyConnection = convertProxyName(proxyActionParameterOperation.getValue());
         outputDataset = convertOutputDatasetReferenceName(setDatasetActionParameterOperation.getValue());
-//        if (getOutputDataset().isPresent()) {
-//            List<String> labels = new ArrayList<>(outputDataset.getLabels());
-//            labels.add("typed");
-//            rawOutputDataset = (KeyValueDataset) DatasetHandler.getInstance().getByNameAndLabels(outputDataset.getName(), labels, getExecutionControl().getExecutionRuntime());
-//        }
 
     }
 
@@ -133,7 +128,6 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         }
         outputResponse(httpResponse);
         ActionPerformanceLogger.getInstance().log(getActionExecution(), "response", httpResponse.getRequestTimestamp(), httpResponse.getResponseTimestamp());
-        //writeResponseToOutputDataset(httpResponse);
         checkStatusCode(httpResponse);
         return true;
     }
@@ -151,7 +145,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
                     .map(this::convertExpectedStatusCode)
                     .collect(Collectors.toList());
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for expectedStatusCode",
+            log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for expectedStatusCode",
                     expectedStatusCodes.getClass()));
             return null;
         }
@@ -161,8 +155,9 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (expectedStatusCode instanceof Text) {
             return expectedStatusCode.toString();
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for expectedStatusCode",
-                    expectedStatusCode.getClass()));
+            log.warn(String.format("%s does not accept %s as type for expectedStatusCode",
+                    getActionExecution().getAction().getType(),
+                            expectedStatusCode.getClass()));
             return expectedStatusCode.toString();
         }
     }
@@ -171,7 +166,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (connectionName == null) {
             return null;
         } else if (connectionName instanceof Text) {
-            return proxyConnection = ConnectionConfiguration.getInstance()
+            return ConnectionConfiguration.getInstance()
                     .get(new ConnectionKey(((Text) connectionName).getString(), getExecutionControl().getEnvName()))
                     .map(ProxyConnection::from)
                     .orElseThrow(() -> new RuntimeException(MessageFormat.format("Cannot find connection {0}", ((Text) connectionName).getString())));
@@ -182,8 +177,13 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private void outputResponse(HttpResponse httpResponse) throws IOException {
-        if (getOutputDataset().isPresent()) {
-            HttpResponseService.getInstance().writeToDataset(httpResponse, getOutputDataset().get(), getExecutionControl().getExecutionRuntime());
+        Optional<KeyValueDataset> outputDataset = getOutputDataset();
+        if (outputDataset.isPresent()) {
+            if (KeyValueDatasetService.getInstance().isEmpty(outputDataset.get())) {
+                log.warn(String.format("Output dataset %s already contains data items. Clearing old data items before writing output", outputDataset.get()));
+                KeyValueDatasetService.getInstance().clean(outputDataset.get(), getExecutionControl().getExecutionRuntime());
+            }
+            HttpResponseService.getInstance().writeToDataset(httpResponse, outputDataset.get(), getExecutionControl().getExecutionRuntime());
         }
         HttpResponseService.getInstance().traceOutput(httpResponse, getActionExecution().getActionControl());
 
@@ -197,8 +197,10 @@ public class HttpExecuteRequest extends ActionTypeExecution {
                     .getDataset(((Text) outputDatasetReferenceName).getString())
                     .map(dataset -> (KeyValueDataset) dataset)
                     .orElseThrow(() -> new RuntimeException(MessageFormat.format("No dataset found with name ''{0}''", ((Text) outputDatasetReferenceName).getString())));
+        } else if (outputDatasetReferenceName instanceof KeyValueDataset) {
+            return (KeyValueDataset) outputDatasetReferenceName;
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for OutputDatasetReferenceName",
+            log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for OutputDatasetReferenceName",
                     outputDatasetReferenceName.getClass()));
             throw new RuntimeException(MessageFormat.format("Output dataset does not allow type ''{0}''", outputDatasetReferenceName.getClass()));
         }
@@ -211,7 +213,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (setRuntimeVariables instanceof Text) {
             return setRuntimeVariables.toString().equalsIgnoreCase("y");
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for setRuntimeVariablesActionParameterOperation",
+            log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for setRuntimeVariablesActionParameterOperation",
                     setRuntimeVariables.getClass()));
             return false;
         }
@@ -224,7 +226,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (httpRequestBody instanceof Text) {
             return Optional.of(httpRequestBody.toString());
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for request body",
+            log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for request body",
                     httpRequestBody.getClass()));
             return Optional.of(httpRequestBody.toString());
         }
@@ -234,7 +236,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (httpRequestName instanceof Text) {
             return ((Text) httpRequestName).getString();
         } else {
-            LOGGER.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for request name",
+            log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for request name",
                     httpRequestName.getClass()));
             return httpRequestName.toString();
         }
@@ -247,7 +249,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
             } else {
                 getActionExecution().getActionControl().logOutput("action.error", MessageFormat.format("Status code of response {0} is not member of expected status codes {1}",
                         httpResponse.getStatusLine().getStatusCode(), expectedStatusCodes));
-                LOGGER.warn(MessageFormat.format("Status code of response {0} is not member of expected status codes {1}",
+                log.warn(MessageFormat.format("Status code of response {0} is not member of expected status codes {1}",
                         httpResponse.getStatusLine().getStatusCode(), expectedStatusCodes));
                 getActionExecution().getActionControl().increaseErrorCount();
             }
@@ -266,7 +268,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         } else {
             getActionExecution().getActionControl().logOutput("action.error", MessageFormat.format("Status code of response {0} is not member of success status codes (1XX, 2XX, 3XX).",
                     httpResponse.getStatusLine().getStatusCode()));
-            LOGGER.warn(MessageFormat.format("Status code of response {0} is not member of success status codes (1XX, 2XX, 3XX).",
+            log.warn(MessageFormat.format("Status code of response {0} is not member of success status codes (1XX, 2XX, 3XX).",
                     httpResponse.getStatusLine().getStatusCode()));
             getActionExecution().getActionControl().increaseErrorCount();
         }

--- a/core/java/iesi-core/src/main/resources/application-repository.yml
+++ b/core/java/iesi-core/src/main/resources/application-repository.yml
@@ -11,6 +11,10 @@ iesi:
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
           # init_sql: alter  current....
+
+#          type: sqlite
+#          file: 
+
           type: h2
           mode: memory
           database: test

--- a/core/java/iesi-core/src/main/resources/application.yml
+++ b/core/java/iesi-core/src/main/resources/application.yml
@@ -6,7 +6,7 @@ iesi:
 #    execution:
 #       runtime: ''
   server:
-    mode: off
-#    mode: standalone
-#    threads:
-#      timeout: 30
+#    mode: off
+    mode: standalone
+    threads:
+      timeout: 30

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/configuration/security/disabled/DisabledWebSecurityConfiguration.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/configuration/security/disabled/DisabledWebSecurityConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,9 +14,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,7 +42,6 @@ public class DisabledWebSecurityConfiguration extends WebSecurityConfigurerAdapt
         http
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .cors(withDefaults())
                 .cors().and()
                 .csrf().disable()
                 .authorizeRequests().anyRequest().permitAll();
@@ -53,6 +55,8 @@ public class DisabledWebSecurityConfiguration extends WebSecurityConfigurerAdapt
         configuration.setAllowedOrigins(Stream.of("*").collect(Collectors.toList()));
         configuration.setAllowedMethods(Stream.of(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.OPTIONS.name(), HttpMethod.DELETE.name())
                 .collect(Collectors.toList()));
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowCredentials(true);
         source.registerCorsConfiguration("/**", configuration);
         return new CorsFilter(source);
     }

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
@@ -10,6 +10,9 @@ iesi:
 
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
+#          type: sqlite
+#          file:
+
           type: h2
           mode: memory
           database: test


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When storing the output of a http.executeRequest in a dataset I want to be able to give an already existing dataset. The expected behaviour is that the dataset will be updated with the latest output

**Id**
d946992