### PR TITLE
IESI rest server complains about duplicate bean name 

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/configuration/IESIMetadataRepositoryConfiguration.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/configuration/IESIMetadataRepositoryConfiguration.java
@@ -1,18 +1,19 @@
 package io.metadew.iesi.server.rest.configuration;
 
+import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.annotation.Order;
 
 @Configuration
-public class MetadataRepositoryConfiguration {
+public class IESIMetadataRepositoryConfiguration {
 
     @Bean
     @DependsOn("frameworkInstance")
     @Order(0)
-    public io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration metadataRepositoryConfiguration() {
-        return io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration.getInstance();
+    public MetadataRepositoryConfiguration metadataRepositoryConfiguration() {
+        return MetadataRepositoryConfiguration.getInstance();
     }
 
 

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
@@ -10,8 +10,14 @@ iesi:
 
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
-          type: sqlite
-          file: /home/robbe/IESISandbox/0.6.0/dataset_pagination/repository.db3
+          type: h2
+          mode: memory
+          database: test;ALIAS_COLUMN_NAME=TRUE
+          owner:
+            user: ""
+            password: ""
+#          type: sqlite
+#          file: /home/robbe/IESISandbox/0.6.0/dataset_pagination/repository.db3
 #          type: h2
 #          mode: memory
 #          database: test

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
@@ -17,13 +17,7 @@ iesi:
             user: ""
             password: ""
 #          type: sqlite
-#          file: /home/robbe/IESISandbox/0.6.0/dataset_pagination/repository.db3
-#          type: h2
-#          mode: memory
-#          database: test
-#          owner:
-#            user: ""
-#            password: ""
+#          file:
 
 #          type: h2
 #          mode: embedded

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/dataset/dto/DatasetDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/dataset/dto/DatasetDtoRepositoryTest.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = Application.class, properties = {"spring.main.allow-bean-definition-overriding=true"})
@@ -81,7 +81,7 @@ class DatasetDtoRepositoryTest {
     }
 
     @Test
-    void getAllPaginatedNoImplementationsLinkedToDatasetPageOverflow() {
+    void getAllPaginatedNoImplementationsLinkedToDatasetPageOverflow() throws InterruptedException {
         Dataset dataset1 = Dataset.builder()
                 .metadataKey(new DatasetKey(UUID.randomUUID()))
                 .name("dataset1")
@@ -99,6 +99,8 @@ class DatasetDtoRepositoryTest {
                 .build();
         datasetConfiguration.insert(dataset1);
         datasetConfiguration.insert(dataset2);
+        // sleep needed for the ordering of the datasets based on load timestamps
+        sleep(1);
         datasetConfiguration.insert(dataset3);
         DatasetDto datasetDto3 = DatasetDto.builder()
                 .uuid(dataset3.getMetadataKey().getUuid())

--- a/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-repository.yml
@@ -11,7 +11,7 @@ iesi:
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
 #          type: sqlite
-#          file: ./test.db3
+#          file: 
           type: h2
           mode: memory
           database: test;ALIAS_COLUMN_NAME=TRUE


### PR DESCRIPTION
**Describe the bug**
```
***************************
APPLICATION FAILED TO START
***************************

Description:

The bean 'metadataRepositoryConfiguration', defined in class path resource [io/metadew/iesi/server/rest/configuration/MetadataRepositoryConfiguration.class], could not be registered. A bean with that name has already been defined in URL [jar:file:/home/robbe/git/iesi/core/java/iesi-rest-without-microservices/target/iesi-rest-0.6.0.jar!/BOOT-INF/classes!/io/metadew/iesi/server/rest/configuration/MetadataRepositoryConfiguration.class] and overriding is disabled.

Action:

Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true
```

**ID**
3499bf3