### PR TITLE
Dataset implementation item creation causes full delete and create  

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/http/response/HttpResponseService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/connection/http/response/HttpResponseService.java
@@ -14,13 +14,13 @@ import java.util.stream.Collectors;
 
 public class HttpResponseService implements IHttpResponseService {
 
-    private static HttpResponseService INSTANCE;
+    private static HttpResponseService instance;
 
-    public synchronized static HttpResponseService getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new HttpResponseService();
+    public static synchronized HttpResponseService getInstance() {
+        if (instance == null) {
+            instance = new HttpResponseService();
         }
-        return INSTANCE;
+        return instance;
     }
 
     public void writeToDataset(HttpResponse httpResponse, InMemoryDatasetImplementation dataset, ExecutionRuntime executionRuntime) throws IOException {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/DataTypeHandler.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/DataTypeHandler.java
@@ -24,19 +24,19 @@ import java.util.regex.Pattern;
 @Log4j2
 public class DataTypeHandler {
 
-    private static final String DatatypeStartCharacters = "{{";
-    private static final String DatatypeStopCharacters = "}}";
-    private static final Pattern DatatypePattern = Pattern.compile("\\^(?<datatype>\\w+)\\((?<arguments>.+)\\)");
+    private static final String DATATYPE_START_CHARACTERS = "{{";
+    private static final String DATATYPE_STOP_CHARACTERS = "}}";
+    private static final Pattern DATATYPE_PATTERN = Pattern.compile("\\^(?<datatype>\\w+)\\((?<arguments>.+)\\)");
 
     private Map<ClassStringPair, IDataTypeService> dataTypeServiceMap;
 
-    private static DataTypeHandler INSTANCE;
+    private static DataTypeHandler instance;
 
     public static synchronized DataTypeHandler getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new DataTypeHandler();
+        if (instance == null) {
+            instance = new DataTypeHandler();
         }
-        return INSTANCE;
+        return instance;
     }
 
     private DataTypeHandler() {
@@ -56,8 +56,8 @@ public class DataTypeHandler {
             return new Null();
         }
         log.trace(MessageFormat.format("resolving {0} for datatype", input));
-        if (input.startsWith(DatatypeStartCharacters) && input.endsWith(DatatypeStopCharacters)) {
-            Matcher matcher = DatatypePattern.matcher(input.substring(DatatypeStartCharacters.length(), input.length() - DatatypeStopCharacters.length()));
+        if (input.startsWith(DATATYPE_START_CHARACTERS) && input.endsWith(DATATYPE_STOP_CHARACTERS)) {
+            Matcher matcher = DATATYPE_PATTERN.matcher(input.substring(DATATYPE_START_CHARACTERS.length(), input.length() - DATATYPE_STOP_CHARACTERS.length()));
             if (matcher.find()) {
                 return getDataTypeService(matcher.group("datatype"))
                         .resolve(matcher.group("arguments"), executionRuntime);

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/DatasetConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/DatasetConfiguration.java
@@ -18,17 +18,17 @@ import java.util.stream.Collectors;
 
 public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
 
-    private static String existQuery = "SELECT " +
+    private static final String EXIST_QUERY = "SELECT " +
             "datasets.NAME as dataset_name, datasets.ID as dataset_id " +
             "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() + " datasets " +
             "WHERE datasets.ID = {0}";
 
-    private static String existByNameQuery = "SELECT " +
-            "datasets.NAME as dataset_name, datasets.ID as dataset_id " +
+    private static final String FETCH_ID_BY_NAME = "SELECT " +
+            "datasets.ID as dataset_id " +
             "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() + " datasets " +
             "WHERE datasets.NAME = {0}";
 
-    private static String fetchSingleQuery = "SELECT " +
+    private static final String FETCH_SINGLE_QUERY = "SELECT " +
             "dataset_impls.ID as dataset_impl_id, " +
             "datasets.NAME as dataset_name, datasets.ID as dataset_id, " +
             "dataset_impl_labels.ID as dataset_impl_label_id, dataset_impl_labels.DATASET_IMPL_ID as dataset_impl_label_impl_id, dataset_impl_labels.VALUE as dataset_impl_label_value, " +
@@ -45,7 +45,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
             "on dataset_impls.ID = dataset_impl_labels.DATASET_IMPL_ID " +
             "where datasets.ID={0};";
 
-    private static String fetchQuery = "SELECT " +
+    private static final String FETCH_QUERY = "SELECT " +
             "dataset_impls.ID as dataset_impl_id, " +
             "datasets.NAME as dataset_name, datasets.ID as dataset_id, " +
             "dataset_impl_labels.ID as dataset_impl_label_id, dataset_impl_labels.DATASET_IMPL_ID as dataset_impl_label_impl_id, dataset_impl_labels.VALUE as dataset_impl_label_value, " +
@@ -61,7 +61,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
             "left outer join " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetImplementationLabels").getName() + " dataset_impl_labels " +
             "on dataset_impls.ID = dataset_impl_labels.DATASET_IMPL_ID;";
 
-    private static String fetchByNameQuery = "SELECT " +
+    private static final String FETCH_BY_NAME_QUERY = "SELECT " +
             "dataset_impls.ID as dataset_impl_id, " +
             "datasets.NAME as dataset_name, datasets.ID as dataset_id, " +
             "dataset_impl_labels.ID as dataset_impl_label_id, dataset_impl_labels.DATASET_IMPL_ID as dataset_impl_label_impl_id, dataset_impl_labels.VALUE as dataset_impl_label_value, " +
@@ -78,14 +78,14 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
             "on dataset_impls.ID = dataset_impl_labels.DATASET_IMPL_ID " +
             "WHERE datasets.NAME={0};";
 
-    private static String existsByNameQuery = "SELECT " +
+    private static final String EXISTS_BY_NAME_QUERY = "SELECT " +
             "datasets.NAME as dataset_name, datasets.ID as dataset_id " +
             " FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() + " datasets " +
             "WHERE datasets.NAME={0};";
 
-    private static String insertQuery = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() +
+    private static final String INSERT_QUERY = "INSERT INTO " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() +
             " (ID, NAME) VALUES ({0}, {1})";
-    private static String deleteQuery = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() +
+    private static final String DELETE_QUERY = "DELETE FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("Datasets").getName() +
             " WHERE ID={0}";
 
 
@@ -111,7 +111,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
         try {
             Map<String, DatasetBuilder> datasetBuilderMap = new LinkedHashMap<>();
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
-                    MessageFormat.format(fetchSingleQuery, SQLTools.getStringForSQL(metadataKey.getUuid())),
+                    MessageFormat.format(FETCH_SINGLE_QUERY, SQLTools.getStringForSQL(metadataKey.getUuid())),
                     "reader");
             while (cachedRowSet.next()) {
                 mapRow(cachedRowSet, datasetBuilderMap);
@@ -128,7 +128,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
     public boolean exists(DatasetKey metadataKey) {
         try {
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
-                    MessageFormat.format(existQuery, SQLTools.getStringForSQL(metadataKey.getUuid())),
+                    MessageFormat.format(EXIST_QUERY, SQLTools.getStringForSQL(metadataKey.getUuid())),
                     "reader");
             return cachedRowSet.next();
         } catch (SQLException e) {
@@ -140,7 +140,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
         try {
             Map<String, DatasetBuilder> datasetBuilderMap = new LinkedHashMap<>();
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
-                    MessageFormat.format(fetchByNameQuery, SQLTools.getStringForSQL(name)),
+                    MessageFormat.format(FETCH_BY_NAME_QUERY, SQLTools.getStringForSQL(name)),
                     "reader");
             while (cachedRowSet.next()) {
                 mapRow(cachedRowSet, datasetBuilderMap);
@@ -156,7 +156,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
     public boolean existsByName(String name) {
         try {
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
-                    MessageFormat.format(existsByNameQuery, SQLTools.getStringForSQL(name)),
+                    MessageFormat.format(EXISTS_BY_NAME_QUERY, SQLTools.getStringForSQL(name)),
                     "reader");
             return cachedRowSet.next();
         } catch (SQLException e) {
@@ -167,7 +167,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
     public Optional<DatasetKey> getIdByName(String name) {
         try {
             CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
-                    MessageFormat.format(existsByNameQuery, SQLTools.getStringForSQL(name)),
+                    MessageFormat.format(FETCH_ID_BY_NAME, SQLTools.getStringForSQL(name)),
                     "reader");
             if (cachedRowSet.next()) {
                 return Optional.of(new DatasetKey(UUID.fromString(cachedRowSet.getString("dataset_id"))));
@@ -183,7 +183,7 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
     public List<Dataset> getAll() {
         try {
             Map<String, DatasetBuilder> datasetBuilderMap = new LinkedHashMap<>();
-            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(fetchQuery,
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(FETCH_QUERY,
                     "reader");
             while (cachedRowSet.next()) {
                 mapRow(cachedRowSet, datasetBuilderMap);
@@ -202,13 +202,13 @@ public class DatasetConfiguration extends Configuration<Dataset, DatasetKey> {
                 .getByDatasetId(datasetKey);
         datasetImplementations
                 .forEach(datasetImplementation -> DatasetImplementationConfiguration.getInstance().delete(datasetImplementation.getMetadataKey()));
-        getMetadataRepository().executeUpdate(MessageFormat.format(deleteQuery,
+        getMetadataRepository().executeUpdate(MessageFormat.format(DELETE_QUERY,
                 SQLTools.getStringForSQL(datasetKey.getUuid().toString())));
     }
 
     @Override
     public void insert(Dataset dataset) {
-        getMetadataRepository().executeUpdate(MessageFormat.format(insertQuery,
+        getMetadataRepository().executeUpdate(MessageFormat.format(INSERT_QUERY,
                 SQLTools.getStringForSQL(dataset.getMetadataKey().getUuid()),
                 SQLTools.getStringForSQL(dataset.getName())));
         dataset.getDatasetImplementations()

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/DatasetImplementationConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/DatasetImplementationConfiguration.java
@@ -5,6 +5,7 @@ import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.datatypes.dataset.DatasetKey;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValue;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValueConfiguration;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValueKey;
 import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabel;
 import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabelKey;
@@ -159,6 +160,7 @@ public class DatasetImplementationConfiguration extends Configuration<DatasetImp
 
     public void init(MetadataRepository metadataRepository) {
         setMetadataRepository(metadataRepository);
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance().init(metadataRepository);
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/IDatasetImplementationService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/IDatasetImplementationService.java
@@ -1,6 +1,7 @@
 package io.metadew.iesi.datatypes.dataset.implementation;
 
 import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes.dataset.Dataset;
 import io.metadew.iesi.datatypes.dataset.DatasetKey;
 import io.metadew.iesi.script.execution.ExecutionRuntime;
 
@@ -11,6 +12,12 @@ import java.util.Optional;
 public interface IDatasetImplementationService<T extends DatasetImplementation> {
 
     Optional<T> getDatasetImplementation(String name, List<String> labels);
+
+    Optional<T> getDatasetImplementation(DatasetKey datasetKey, List<String> labels);
+
+    T createNewDatasetImplementation(Dataset dataset, List<String> labels);
+
+    T createNewDatasetImplementation(DatasetKey datasetKey, String name, List<String> labels);
 
     T createNewDatasetImplementation(String name, List<String> labels);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationKeyValueConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationKeyValueConfiguration.java
@@ -1,0 +1,205 @@
+package io.metadew.iesi.datatypes.dataset.implementation.inmemory;
+
+import io.metadew.iesi.common.configuration.metadata.tables.MetadataTablesConfiguration;
+import io.metadew.iesi.connection.tools.SQLTools;
+import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationKey;
+import io.metadew.iesi.metadata.configuration.Configuration;
+import io.metadew.iesi.metadata.repository.MetadataRepository;
+import lombok.extern.log4j.Log4j2;
+
+import javax.sql.rowset.CachedRowSet;
+import java.sql.SQLException;
+import java.text.MessageFormat;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Log4j2
+public class InMemoryDatasetImplementationKeyValueConfiguration extends Configuration<InMemoryDatasetImplementationKeyValue, InMemoryDatasetImplementationKeyValueKey> {
+
+    private static final String EXISTS_QUERY = "SELECT " +
+            "dataset_in_mem_impl_kvs.ID as dataset_in_mem_impl_kv_id, dataset_in_mem_impl_kvs.IMPL_MEM_ID as dataset_in_mem_impl_kv_impl_id, dataset_in_mem_impl_kvs.KEY as dataset_in_mem_impl_kvs_key, dataset_in_mem_impl_kvs.VALUE as dataset_in_mem_impl_kvs_value " +
+            "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() + " dataset_in_mem_impl_kvs " +
+            "where dataset_in_mem_impl_kvs.ID={0};";
+
+    private static final String SELECT_QUERY = "SELECT " +
+            "dataset_in_mem_impl_kvs.ID as dataset_in_mem_impl_kv_id, dataset_in_mem_impl_kvs.IMPL_MEM_ID as dataset_in_mem_impl_kv_impl_id, dataset_in_mem_impl_kvs.KEY as dataset_in_mem_impl_kvs_key, dataset_in_mem_impl_kvs.VALUE as dataset_in_mem_impl_kvs_value " +
+            "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() + " dataset_in_mem_impl_kvs;";
+
+    private static final String SELECT_SINGLE_QUERY = "SELECT " +
+            "dataset_in_mem_impl_kvs.ID as dataset_in_mem_impl_kv_id, dataset_in_mem_impl_kvs.IMPL_MEM_ID as dataset_in_mem_impl_kv_impl_id, dataset_in_mem_impl_kvs.KEY as dataset_in_mem_impl_kvs_key, dataset_in_mem_impl_kvs.VALUE as dataset_in_mem_impl_kvs_value " +
+            "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() + " dataset_in_mem_impl_kvs " +
+            "where dataset_in_mem_impl_kvs.ID={0};";
+
+    private static final String SELECT_BY_DATASET_IMPL_ID_QUERY = "SELECT " +
+            "dataset_in_mem_impl_kvs.ID as dataset_in_mem_impl_kv_id, dataset_in_mem_impl_kvs.IMPL_MEM_ID as dataset_in_mem_impl_kv_impl_id, dataset_in_mem_impl_kvs.KEY as dataset_in_mem_impl_kvs_key, dataset_in_mem_impl_kvs.VALUE as dataset_in_mem_impl_kvs_value " +
+            "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() + " dataset_in_mem_impl_kvs " +
+            "where dataset_in_mem_impl_kvs.IMPL_MEM_ID={0};";
+
+    private static final String SELECT_BY_DATASET_IMPL_ID_AND_KEY_QUERY = "SELECT " +
+            "dataset_in_mem_impl_kvs.ID as dataset_in_mem_impl_kv_id, dataset_in_mem_impl_kvs.IMPL_MEM_ID as dataset_in_mem_impl_kv_impl_id, dataset_in_mem_impl_kvs.KEY as dataset_in_mem_impl_kvs_key, dataset_in_mem_impl_kvs.VALUE as dataset_in_mem_impl_kvs_value " +
+            "FROM " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() + " dataset_in_mem_impl_kvs " +
+            "where dataset_in_mem_impl_kvs.IMPL_MEM_ID={0} and dataset_in_mem_impl_kvs.KEY={1};";
+
+    private static final String INSERT_QUERY = "insert into " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() +
+            " (ID, IMPL_MEM_ID, KEY, VALUE) " +
+            "VALUES ({0}, {1}, {2}, {3});";
+
+    private static final String DELETE_QUERY = "delete from " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() +
+            " WHERE ID={0};";
+
+    private static final String DELETE_BY_DATASET_IMPLEMENTATION_ID_QUERY = "delete from " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() +
+            " WHERE IMPL_MEM_ID={0};";
+
+    private static String UPDATE_QUERY = "UPDATE " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel("DatasetInMemoryImplementationKeyValues").getName() +
+            " SET IMPL_MEM_ID = {0}, KEY ={1}, VALUE = {2}" +
+            " WHERE ID = {3};";
+
+    private static InMemoryDatasetImplementationKeyValueConfiguration instance;
+
+    public static synchronized InMemoryDatasetImplementationKeyValueConfiguration getInstance() {
+        if (instance == null) {
+            instance = new InMemoryDatasetImplementationKeyValueConfiguration();
+        }
+        return instance;
+    }
+
+    private InMemoryDatasetImplementationKeyValueConfiguration() {
+    }
+
+    public void init(MetadataRepository metadataRepository) {
+        setMetadataRepository(metadataRepository);
+    }
+
+    @Override
+    public boolean exists(InMemoryDatasetImplementationKeyValueKey inMemoryDatasetImplementationKeyValueKey) {
+        try {
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
+                    MessageFormat.format(EXISTS_QUERY, SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValueKey.getUuid())),
+                    "reader");
+            return cachedRowSet.next();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<InMemoryDatasetImplementationKeyValue> get(InMemoryDatasetImplementationKeyValueKey inMemoryDatasetImplementationKeyValueKey) {
+        try {
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
+                    MessageFormat.format(SELECT_SINGLE_QUERY, SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValueKey.getUuid())),
+                    "reader");
+            if (cachedRowSet.size() > 1) {
+                log.warn(String.format("found more than 1 %s with id %s", InMemoryDatasetImplementationKeyValue.class.getSimpleName(), inMemoryDatasetImplementationKeyValueKey));
+            }
+            if (cachedRowSet.next()) {
+                return Optional.of(mapRow(cachedRowSet));
+            } else {
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<InMemoryDatasetImplementationKeyValue> getByDatasetImplementationId(DatasetImplementationKey datasetImplementationKey) {
+        try {
+            List<InMemoryDatasetImplementationKeyValue> inMemoryDatasetImplementationKeyValues = new LinkedList<>();
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
+                    MessageFormat.format(SELECT_BY_DATASET_IMPL_ID_QUERY,
+                            SQLTools.getStringForSQL(datasetImplementationKey.getUuid())),
+                    "reader");
+            while (cachedRowSet.next()) {
+                inMemoryDatasetImplementationKeyValues.add(mapRow(cachedRowSet));
+            }
+            return inMemoryDatasetImplementationKeyValues;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Optional<InMemoryDatasetImplementationKeyValue> getByDatasetImplementationIdAndKey(DatasetImplementationKey datasetImplementationKey, String key) {
+        try {
+            List<InMemoryDatasetImplementationKeyValue> inMemoryDatasetImplementationKeyValues = new LinkedList<>();
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
+                    MessageFormat.format(SELECT_BY_DATASET_IMPL_ID_AND_KEY_QUERY,
+                            SQLTools.getStringForSQL(datasetImplementationKey.getUuid()),
+                            SQLTools.getStringForSQL(key)),
+                    "reader");
+            if (cachedRowSet.size() > 1) {
+                log.warn(String.format("found more than 1 %s with dataset implementation id %s and key %s", InMemoryDatasetImplementationKeyValue.class.getSimpleName(), datasetImplementationKey, key));
+            }
+            if (cachedRowSet.next()) {
+                return Optional.of(mapRow(cachedRowSet));
+            } else {
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<InMemoryDatasetImplementationKeyValue> getAll() {
+        try {
+            List<InMemoryDatasetImplementationKeyValue> inMemoryDatasetImplementationKeyValues = new LinkedList<>();
+            CachedRowSet cachedRowSet = getMetadataRepository().executeQuery(
+                    SELECT_QUERY,
+                    "reader");
+            while (cachedRowSet.next()) {
+                inMemoryDatasetImplementationKeyValues.add(mapRow(cachedRowSet));
+            }
+            return inMemoryDatasetImplementationKeyValues;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(InMemoryDatasetImplementationKeyValueKey inMemoryDatasetImplementationKeyValueKey) {
+        getMetadataRepository().executeUpdate(MessageFormat.format(DELETE_QUERY,
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValueKey.getUuid())));
+    }
+
+    public void deleteByDatasetImplementationId(DatasetImplementationKey datasetImplementationKey) {
+        getMetadataRepository().executeUpdate(MessageFormat.format(DELETE_BY_DATASET_IMPLEMENTATION_ID_QUERY,
+                SQLTools.getStringForSQL(datasetImplementationKey.getUuid())));
+    }
+
+    @Override
+    public void insert(InMemoryDatasetImplementationKeyValue inMemoryDatasetImplementationKeyValue) {
+        getMetadataRepository().executeUpdate(MessageFormat.format(INSERT_QUERY,
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getMetadataKey().getUuid()),
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getDatasetImplementationKey().getUuid()),
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getKey()),
+                SQLTools.getStringForSQLClob(inMemoryDatasetImplementationKeyValue.getValue(),
+                        getMetadataRepository().getRepositoryCoordinator().getDatabases().values().stream()
+                                .findFirst()
+                                .orElseThrow(RuntimeException::new)
+                )));
+    }
+
+    @Override
+    public void update(InMemoryDatasetImplementationKeyValue inMemoryDatasetImplementationKeyValue) {
+        getMetadataRepository().executeUpdate(MessageFormat.format(UPDATE_QUERY,
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getDatasetImplementationKey().getUuid()),
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getKey()),
+                SQLTools.getStringForSQLClob(inMemoryDatasetImplementationKeyValue.getValue(),
+                        getMetadataRepository().getRepositoryCoordinator().getDatabases().values().stream()
+                                .findFirst()
+                                .orElseThrow(RuntimeException::new)
+                ),
+                SQLTools.getStringForSQL(inMemoryDatasetImplementationKeyValue.getMetadataKey().getUuid())));
+    }
+
+    public InMemoryDatasetImplementationKeyValue mapRow(CachedRowSet cachedRowSet) throws SQLException {
+        String inMemoryKeyValueId = cachedRowSet.getString("dataset_in_mem_impl_kv_id");
+        String clobValue = SQLTools.getStringFromSQLClob(cachedRowSet, "dataset_in_mem_impl_kvs_value");
+        return new InMemoryDatasetImplementationKeyValue(
+                new InMemoryDatasetImplementationKeyValueKey(UUID.fromString(inMemoryKeyValueId)),
+                new DatasetImplementationKey(UUID.fromString(cachedRowSet.getString("dataset_in_mem_impl_kv_impl_id"))),
+                cachedRowSet.getString("dataset_in_mem_impl_kvs_key"),
+                clobValue);
+    }
+}

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
@@ -44,14 +44,52 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
     }
 
     @Override
+    public Optional<InMemoryDatasetImplementation> getDatasetImplementation(DatasetKey datasetKey, List<String> labels) {
+        return DatasetImplementationConfiguration.getInstance().getByDatasetIdAndLabels(datasetKey, labels)
+                .map(datasetImplementation -> (InMemoryDatasetImplementation) datasetImplementation);
+    }
+
+    @Override
+    public InMemoryDatasetImplementation createNewDatasetImplementation(Dataset dataset, List<String> labels) {
+        DatasetImplementationKey datasetImplementationKey = new DatasetImplementationKey();
+        InMemoryDatasetImplementation inMemoryDatasetImplementation = new InMemoryDatasetImplementation(
+                datasetImplementationKey,
+                dataset.getMetadataKey(),
+                dataset.getName(),
+                labels.stream()
+                        .map(s -> new DatasetImplementationLabel(new DatasetImplementationLabelKey(), datasetImplementationKey, s))
+                        .collect(Collectors.toSet()),
+                new HashSet<>()
+        );
+        DatasetImplementationConfiguration.getInstance().insert(inMemoryDatasetImplementation);
+        return inMemoryDatasetImplementation;
+    }
+
+    @Override
+    public InMemoryDatasetImplementation createNewDatasetImplementation(DatasetKey datasetKey, String name, List<String> labels) {
+        DatasetImplementationKey datasetImplementationKey = new DatasetImplementationKey();
+        InMemoryDatasetImplementation inMemoryDatasetImplementation = new InMemoryDatasetImplementation(
+                datasetImplementationKey,
+                datasetKey,
+                name,
+                labels.stream()
+                        .map(s -> new DatasetImplementationLabel(new DatasetImplementationLabelKey(), datasetImplementationKey, s))
+                        .collect(Collectors.toSet()),
+                new HashSet<>()
+        );
+        DatasetImplementationConfiguration.getInstance().insert(inMemoryDatasetImplementation);
+        return inMemoryDatasetImplementation;
+    }
+
+    @Override
     public InMemoryDatasetImplementation createNewDatasetImplementation(String name, List<String> labels) {
-        Dataset dataset;
-        if (DatasetConfiguration.getInstance().getByName(name).isPresent()) {
-            dataset = DatasetConfiguration.getInstance().getByName(name).get();
-        } else {
-            dataset = new Dataset(new DatasetKey(), name, new HashSet<>());
-            DatasetConfiguration.getInstance().insert(dataset);
-        }
+        Dataset dataset = DatasetConfiguration.getInstance().getByName(name)
+                .orElseGet(() -> {
+                    Dataset newDataset = new Dataset(new DatasetKey(), name, new HashSet<>());
+                    DatasetConfiguration.getInstance().insert(newDataset);
+                    return newDataset;
+                });
+
         DatasetImplementationKey datasetImplementationKey = new DatasetImplementationKey();
         InMemoryDatasetImplementation inMemoryDatasetImplementation = new InMemoryDatasetImplementation(
                 datasetImplementationKey,
@@ -91,23 +129,20 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
 
     @Override
     public Optional<DataType> getDataItem(InMemoryDatasetImplementation datasetImplementation, String dataItem, ExecutionRuntime executionRuntime) {
-        return datasetImplementation.getKeyValues().stream()
-                .filter(inMemoryDatasetImplementationKeyValue -> inMemoryDatasetImplementationKeyValue.getKey().equals(dataItem))
-                .findFirst()
+        return InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(datasetImplementation.getMetadataKey(), dataItem)
                 .map(inMemoryDatasetImplementationKeyValue -> DataTypeHandler.getInstance().resolve(inMemoryDatasetImplementationKeyValue.getValue(), executionRuntime));
     }
 
     @Override
     public Map<String, DataType> getDataItems(InMemoryDatasetImplementation datasetImplementation, ExecutionRuntime executionRuntime) {
         // https://bugs.openjdk.java.net/browse/JDK-8148463
-        HashMap<String, DataType> map = new HashMap<>();
-        datasetImplementation.getKeyValues().forEach(
-                inMemoryDatasetImplementationKeyValue -> {
-                    DataType dataType = DataTypeHandler.getInstance().resolve(inMemoryDatasetImplementationKeyValue.getValue(), executionRuntime);
-                    map.put(inMemoryDatasetImplementationKeyValue.getKey(), dataType);
-                }
-        );
-        return map;
+        return InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationId(datasetImplementation.getMetadataKey())
+                .stream()
+                .collect(Collectors.toMap(InMemoryDatasetImplementationKeyValue::getKey,
+                        inMemoryDatasetImplementationKeyValue -> DataTypeHandler.getInstance().resolve(inMemoryDatasetImplementationKeyValue.getValue(), executionRuntime))
+                );
     }
 
     @Override
@@ -144,14 +179,13 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
         return inMemoryDatasetImplementation;
     }
 
-
     private InMemoryDatasetImplementation getObjectDataset(InMemoryDatasetImplementation inMemoryDatasetImplementation, String keyPrefix) {
         if (keyPrefix != null) {
             List<String> labels = inMemoryDatasetImplementation.getDatasetImplementationLabels().stream()
                     .map(DatasetImplementationLabel::getValue)
                     .collect(Collectors.toList());
             labels.add(keyPrefix);
-            return createNewDatasetImplementation(inMemoryDatasetImplementation.getName(), labels);
+            return createNewDatasetImplementation(inMemoryDatasetImplementation.getDatasetKey(), inMemoryDatasetImplementation.getName(), labels);
         } else {
             return inMemoryDatasetImplementation;
         }
@@ -169,7 +203,7 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
 
     @Override
     public InMemoryDatasetImplementation resolve(String arguments, ExecutionRuntime executionRuntime) {
-        log.trace(MessageFormat.format("resolving {0} for Dataset", arguments));
+        log.trace(MessageFormat.format("resolving {0} for Dataset Implementation", arguments));
         arguments = executionRuntime.resolveVariables(arguments);
         List<String> splittedArguments = DataTypeHandler.getInstance().splitInstructionArguments(arguments);
         if (splittedArguments.size() == 2) {
@@ -178,8 +212,17 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
                     .collect(Collectors.toList());
             return getDatasetImplementation(
                     convertDatasetName(resolvedArguments.get(0)),
-                    convertDatasetLabels(resolvedArguments.get(1), executionRuntime))
-                    .orElseGet(() -> createNewDatasetImplementation(convertDatasetName(resolvedArguments.get(0)), convertDatasetLabels(resolvedArguments.get(1), executionRuntime)));
+                    convertDatasetLabels(resolvedArguments.get(1), executionRuntime)
+            )
+                    .orElseGet(() -> {
+                        DatasetKey datasetKey = DatasetConfiguration.getInstance()
+                            .getIdByName(convertDatasetName(resolvedArguments.get(0)))
+                            .orElseThrow(() -> new RuntimeException(String.format("Cannot find dataset %s", convertDatasetName(resolvedArguments.get(0)))));
+                        return createNewDatasetImplementation(
+                                datasetKey,
+                                convertDatasetName(resolvedArguments.get(0)),
+                                convertDatasetLabels(resolvedArguments.get(1), executionRuntime));
+                    });
         } else {
             throw new RuntimeException(MessageFormat.format("Cannot create dataset with arguments ''{0}''", splittedArguments.toString()));
         }
@@ -249,4 +292,5 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
         }
         return true;
     }
+
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
@@ -70,8 +70,8 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
     public void clean(InMemoryDatasetImplementation datasetImplementation, ExecutionRuntime executionRuntime) {
         InMemoryDatasetImplementationService.getInstance().getDataItems(datasetImplementation, executionRuntime)
                 .forEach((s, dataType) -> deleteDataType(dataType, executionRuntime));
-	datasetImplementation.setKeyValues(new HashSet<>());
-	DatasetImplementationConfiguration.getInstance().update(datasetImplementation);
+        datasetImplementation.setKeyValues(new HashSet<>());
+        DatasetImplementationConfiguration.getInstance().update(datasetImplementation);
     }
 
     @Override
@@ -112,18 +112,20 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
 
     @Override
     public void setDataItem(InMemoryDatasetImplementation datasetImplementation, String key, DataType value) {
-        datasetImplementation.getKeyValues().stream()
-                .filter(inMemoryDatasetImplementationKeyValue -> inMemoryDatasetImplementationKeyValue.getKey().equals(key))
-                .findFirst()
-                .map(inMemoryDatasetImplementationKeyValue -> {
-                    inMemoryDatasetImplementationKeyValue.setValue(value.toString());
-                    return datasetImplementation;
-                })
-                .orElseGet(() -> {
-                    datasetImplementation.getKeyValues().add(new InMemoryDatasetImplementationKeyValue(new InMemoryDatasetImplementationKeyValueKey(), datasetImplementation.getMetadataKey(), key, value.toString()));
-                    return datasetImplementation;
-                });
-        DatasetImplementationConfiguration.getInstance().update(datasetImplementation);
+        Optional<InMemoryDatasetImplementationKeyValue> inMemoryDatasetImplementationKeyValue = InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(datasetImplementation.getMetadataKey(), key);
+        if (inMemoryDatasetImplementationKeyValue.isPresent()) {
+            inMemoryDatasetImplementationKeyValue.get().setValue(value.toString());
+            InMemoryDatasetImplementationKeyValueConfiguration.getInstance().update(inMemoryDatasetImplementationKeyValue.get());
+        } else {
+            InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                    .insert(new InMemoryDatasetImplementationKeyValue(
+                            new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID()),
+                            datasetImplementation.getMetadataKey(),
+                            key,
+                            value.toString()
+                    ));
+        }
     }
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataSetDatasetConnection.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataSetDatasetConnection.java
@@ -119,9 +119,9 @@ public class DataSetDatasetConnection extends ActionTypeExecution {
                 .collect(Collectors.toList());
 
         InMemoryDatasetImplementation inMemoryDatasetImplementation = InMemoryDatasetImplementationService.getInstance()
-                .getDatasetImplementation(datasetName, resolvedDatasetLabels)
+                .getDatasetImplementation(datasetKey, resolvedDatasetLabels)
                 .orElseGet(() -> {
-                    log.warn(MessageFormat.format("DatasetImplementation {0}-{1} does not exists. Creating dataset implementaion now", datasetName, resolvedDatasetLabels));
+                    log.warn(MessageFormat.format("DatasetImplementation {0}-{1} does not exists. Creating dataset implementation now", datasetName, resolvedDatasetLabels));
                     DatasetImplementationKey datasetImplementationKey = new DatasetImplementationKey();
                     InMemoryDatasetImplementation newInMemoryDatasetImplementation = new InMemoryDatasetImplementation(
                             datasetImplementationKey,

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/lookup/DatasetLookup.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/lookup/DatasetLookup.java
@@ -36,15 +36,7 @@ public class DatasetLookup implements LookupInstruction {
 
     @Override
     public String generateOutput(String parameters) {
-//        // TODO: parse with antlr
-//        Matcher inputParameterMatcher = INPUT_PARAMETER_PATTERN.matcher(parameters);
-//        if (!inputParameterMatcher.find()) {
-//            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to dataset lookup: {0}", parameters));
-//        }
-
-//        Dataset dataset = getDataset(dataTypeService.resolve(inputParameterMatcher.group(DATASET_NAME_KEY)));
-//        String datasetItemName = inputParameterMatcher.group(DATASET_ITEM_NAME_KEY);
-
+        // TODO: parse with antlr
 
         String[] arguments = splitInput(parameters);
         InMemoryDatasetImplementation dataset = getDataset(DataTypeHandler.getInstance().resolve(arguments[0].trim(), executionRuntime));

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/connection/http/entity/json/ApplicationJsonHttpResponseEntityServiceTest.java
@@ -27,7 +27,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         InMemoryDatasetImplementationService datasetHandler = mock(InMemoryDatasetImplementationService.class);
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", datasetHandler);
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", dataTypeHandler);
 
         HttpResponse httpResponse = mock(HttpResponse.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
@@ -47,7 +47,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
 
         // Clean up
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", (InMemoryDatasetImplementationService) null);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", (DataTypeHandler) null);
     }
 
     @Test
@@ -56,7 +56,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         InMemoryDatasetImplementationService datasetHandler = mock(InMemoryDatasetImplementationService.class);
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", datasetHandler);
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", dataTypeHandler);
 
         HttpResponse httpResponse = mock(HttpResponse.class);
         when(httpResponse.getEntityContent())
@@ -73,7 +73,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
 
         // Clean up
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", (InMemoryDatasetImplementationService) null);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", (DataTypeHandler) null);
     }
 
     @Test
@@ -82,7 +82,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         InMemoryDatasetImplementationService datasetHandler = mock(InMemoryDatasetImplementationService.class);
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", datasetHandler);
         DataTypeHandler dataTypeHandler = mock(DataTypeHandler.class);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", dataTypeHandler);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", dataTypeHandler);
 
         HttpResponse httpResponse = mock(HttpResponse.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
@@ -99,7 +99,7 @@ class ApplicationJsonHttpResponseEntityServiceTest {
         verify(datasetHandler, times(0)).setDataItem(dataset, "key", new Text("test"));
         // Clean up
         Whitebox.setInternalState(InMemoryDatasetImplementationService.class, "instance", (InMemoryDatasetImplementationService) null);
-        Whitebox.setInternalState(DataTypeHandler.class, "INSTANCE", (DataTypeHandler) null);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", (DataTypeHandler) null);
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/DatasetBuilder.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/DatasetBuilder.java
@@ -1,0 +1,73 @@
+package io.metadew.iesi.datatypes.dataset;
+
+import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationKey;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValue;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValueKey;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabel;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabelKey;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class DatasetBuilder {
+
+    public static Map<String, Object> generateDataset(int datasetIndex, int implementationCount, int labelCount, int keyValueCount) {
+        Map<String, Object> info = new HashMap<>();
+
+        UUID datasetUUID = UUID.randomUUID();
+        info.put("datasetUUID", datasetUUID);
+        Dataset dataset = Dataset.builder()
+                .metadataKey(new DatasetKey(datasetUUID))
+                .name(String.format("dataset%d", datasetIndex))
+                .datasetImplementations(
+                        IntStream.range(0, implementationCount).boxed()
+                                .map(implementationIndex -> {
+                                    UUID datasetImplementationUUID = UUID.randomUUID();
+                                    info.put(String.format("datasetImplementation%dUUID", implementationIndex), datasetImplementationUUID);
+                                    InMemoryDatasetImplementation inMemoryDatasetImplementation = InMemoryDatasetImplementation.builder()
+                                            .metadataKey(new DatasetImplementationKey(datasetImplementationUUID))
+                                            .datasetKey(new DatasetKey(datasetUUID))
+                                            .name(String.format("dataset%d", datasetIndex))
+                                            .datasetImplementationLabels(
+                                                    IntStream.range(0, labelCount).boxed()
+                                                            .map(labelIndex -> {
+                                                                        UUID datasetImplementationLabelUUID = UUID.randomUUID();
+                                                                        info.put(String.format("datasetImplementation%dLabel%dUUID", implementationIndex, labelIndex), datasetImplementationLabelUUID);
+                                                                        DatasetImplementationLabel datasetImplementationLabel = DatasetImplementationLabel.builder()
+                                                                                .metadataKey(new DatasetImplementationLabelKey(datasetImplementationLabelUUID))
+                                                                                .datasetImplementationKey(new DatasetImplementationKey(datasetImplementationUUID))
+                                                                                .value(String.format("label%d%d%d", datasetIndex, implementationIndex, labelIndex))
+                                                                                .build();
+                                                                        info.put(String.format("datasetImplementation%dLabel%d", implementationIndex, labelIndex), datasetImplementationLabel);
+                                                                        return datasetImplementationLabel;
+                                                                    }
+                                                            ).collect(Collectors.toSet()))
+                                            .keyValues(
+                                                    IntStream.range(0, keyValueCount).boxed()
+                                                            .map(keyValueIndex -> {
+                                                                UUID datasetImplementationKeyValueUUID = UUID.randomUUID();
+                                                                info.put(String.format("datasetImplementation%dKeyValue%dUUID", implementationIndex, keyValueIndex), datasetImplementationKeyValueUUID);
+                                                                InMemoryDatasetImplementationKeyValue inMemoryDatasetImplementationKeyValue = InMemoryDatasetImplementationKeyValue.builder()
+                                                                        .metadataKey(new InMemoryDatasetImplementationKeyValueKey(datasetImplementationKeyValueUUID))
+                                                                        .datasetImplementationKey(new DatasetImplementationKey(datasetImplementationUUID))
+                                                                        .key(String.format("key%d%d%d", datasetIndex, implementationIndex, keyValueIndex))
+                                                                        .value(String.format("value%d%d%d", datasetIndex, implementationIndex, keyValueIndex))
+                                                                        .build();
+                                                                info.put(String.format("datasetImplementation%dKeyValue%d", implementationIndex, keyValueIndex), inMemoryDatasetImplementationKeyValue);
+                                                                return inMemoryDatasetImplementationKeyValue;
+                                                            }).collect(Collectors.toSet())
+                                            )
+                                            .build();
+                                    info.put(String.format("datasetImplementation%d", implementationIndex), inMemoryDatasetImplementation);
+                                    return inMemoryDatasetImplementation;
+                                })
+                                .collect(Collectors.toSet()))
+                .build();
+        info.put("dataset", dataset);
+        return info;
+    }
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/DatasetConfigurationTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/DatasetConfigurationTest.java
@@ -1,4 +1,4 @@
-package io.metadew.iesi.metadata.configuration.dataset;
+package io.metadew.iesi.datatypes.dataset;
 
 import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.metadew.iesi.datatypes.dataset.DatasetBuilder.generateDataset;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DatasetConfigurationTest {
@@ -221,54 +222,4 @@ class DatasetConfigurationTest {
                 .isFalse();
     }
 
-    private Map<String, Object> generateDataset(int datasetIndex, int implementationCount, int labelCount, int keyValueCount) {
-        Map<String, Object> info = new HashMap<>();
-
-        UUID datasetUUID = UUID.randomUUID();
-        info.put("datasetUUID", datasetUUID);
-        Dataset dataset = Dataset.builder()
-                .metadataKey(new DatasetKey(datasetUUID))
-                .name(String.format("dataset%d", datasetIndex))
-                .datasetImplementations(
-                        IntStream.range(0, implementationCount).boxed()
-                                .map(implementationIndex -> {
-                                    UUID datasetImplementationUUID = UUID.randomUUID();
-                                    info.put(String.format("datasetImplementation%dUUID", implementationIndex), datasetImplementationUUID);
-                                    return InMemoryDatasetImplementation.builder()
-                                            .metadataKey(new DatasetImplementationKey(datasetImplementationUUID))
-                                            .datasetKey(new DatasetKey(datasetUUID))
-                                            .name(String.format("dataset%d", datasetIndex))
-                                            .datasetImplementationLabels(
-                                                    IntStream.range(0, labelCount).boxed()
-                                                            .map(labelIndex -> {
-                                                                        UUID datasetImplementationLabelUUID = UUID.randomUUID();
-                                                                        info.put(String.format("datasetImplementation%dLabel%dUUID", implementationIndex, labelIndex), datasetImplementationLabelUUID);
-                                                                        return DatasetImplementationLabel.builder()
-                                                                                .metadataKey(new DatasetImplementationLabelKey(datasetImplementationLabelUUID))
-                                                                                .datasetImplementationKey(new DatasetImplementationKey(datasetImplementationUUID))
-                                                                                .value(String.format("label%d%d%d", datasetIndex, implementationIndex, labelIndex))
-                                                                                .build();
-                                                                    }
-                                                            ).collect(Collectors.toSet()))
-                                            .keyValues(
-                                                    IntStream.range(0, keyValueCount).boxed()
-                                                            .map(keyValueIndex -> {
-                                                                UUID datasetImplementationKeyValueUUID = UUID.randomUUID();
-                                                                info.put(String.format("datasetImplementation%dKeyValue%dUUID", implementationIndex, keyValueIndex), datasetImplementationKeyValueUUID);
-
-                                                                return InMemoryDatasetImplementationKeyValue.builder()
-                                                                        .metadataKey(new InMemoryDatasetImplementationKeyValueKey(datasetImplementationKeyValueUUID))
-                                                                        .datasetImplementationKey(new DatasetImplementationKey(datasetImplementationUUID))
-                                                                        .key(String.format("key%d%d%d", datasetIndex, implementationIndex, keyValueIndex))
-                                                                        .value(String.format("value%d%d%d", datasetIndex, implementationIndex, keyValueIndex))
-                                                                        .build();
-                                                            }).collect(Collectors.toSet())
-                                            )
-                                            .build();
-                                })
-                                .collect(Collectors.toSet()))
-                .build();
-        info.put("dataset", dataset);
-        return info;
-    }
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationKeyValueConfigurationTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationKeyValueConfigurationTest.java
@@ -1,0 +1,257 @@
+package io.metadew.iesi.datatypes.dataset.implementation.inmemory;
+
+import io.metadew.iesi.common.configuration.Configuration;
+import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
+import io.metadew.iesi.datatypes.dataset.Dataset;
+import io.metadew.iesi.datatypes.dataset.DatasetConfiguration;
+import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationKey;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValue;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValueConfiguration;
+import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationKeyValueKey;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabel;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabelKey;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.metadew.iesi.datatypes.dataset.DatasetBuilder.generateDataset;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryDatasetImplementationKeyValueConfigurationTest {
+
+    @BeforeAll
+    static void prepare() {
+        Configuration.getInstance();
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository()
+                .createAllTables();
+    }
+
+    @AfterEach
+    void clearDatabase() {
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository().cleanAllTables();
+    }
+
+    @AfterAll
+    static void teardown() {
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository().dropAllTables();
+    }
+
+    @Test
+    void testExists() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .exists(new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap.get("datasetImplementation0KeyValue0UUID"))))
+                .isTrue();
+    }
+
+    @Test
+    void testExistsNotExisting() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .exists(new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID())))
+                .isFalse();
+    }
+
+
+    @Test
+    void testGetById() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .get(new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap.get("datasetImplementation0KeyValue0UUID"))))
+                .hasValue((InMemoryDatasetImplementationKeyValue) datasetMap.get("datasetImplementation0KeyValue0"));
+    }
+
+
+    @Test
+    void testGetByIdDoesNotExist() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 0);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance().get(new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID())))
+                .isEmpty();
+    }
+
+    @Test
+    void testGetAll() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+    }
+
+    @Test
+    void testGetByDatasetImplementationId() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationId(new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID"))))
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"));
+    }
+
+    @Test
+    void testGetByDatasetImplementationIdAndKey() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID")), "key200"))
+                .hasValue((InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"));
+    }
+
+    @Test
+    void testUpdate() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .update(new InMemoryDatasetImplementationKeyValue(
+                        new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap2.get("datasetImplementation0KeyValue0UUID")),
+                        new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID")),
+                        "key",
+                        "value")
+                );
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(new InMemoryDatasetImplementationKeyValue(
+                                new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap2.get("datasetImplementation0KeyValue0UUID")),
+                                new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID")),
+                                "key",
+                                "value"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+    }
+
+    @Test
+    void testGetByDatasetImplementationIdAndKeyNoMatch() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID")), "key202"))
+                .isEmpty();
+    }
+
+    @Test
+    void testGetAllNoDatasets() {
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .isEmpty();
+    }
+
+    @Test
+    void testDeleteDatasets() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .delete(new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap2.get("datasetImplementation0KeyValue0UUID")));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .delete(new InMemoryDatasetImplementationKeyValueKey((UUID) datasetMap1.get("datasetImplementation0KeyValue0UUID")));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+    }
+
+    @Test
+    void testDeleteByDatasetImplementationId() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .deleteByDatasetImplementationId(new DatasetImplementationKey((UUID) datasetMap2.get("datasetImplementation0UUID")));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+    }
+
+    @Test
+    void testInsertDatasets() {
+        Map<String, Object> datasetMap1 = generateDataset(1, 2, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap1.get("dataset"));
+        Map<String, Object> datasetMap2 = generateDataset(2, 1, 1, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap2.get("dataset"));
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+        InMemoryDatasetImplementationKeyValueKey inMemoryDatasetImplementationKeyValueKey = new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID());
+        InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .insert(new InMemoryDatasetImplementationKeyValue(
+                        inMemoryDatasetImplementationKeyValueKey,
+                        new DatasetImplementationKey((UUID) datasetMap1.get("datasetImplementation0UUID")),
+                        "key",
+                        "value")
+                );
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getAll())
+                .containsOnly(
+                        new InMemoryDatasetImplementationKeyValue(
+                                inMemoryDatasetImplementationKeyValueKey,
+                                new DatasetImplementationKey((UUID) datasetMap1.get("datasetImplementation0UUID")),
+                                "key",
+                                "value"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap2.get("datasetImplementation0KeyValue1"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation0KeyValue0"),
+                        (InMemoryDatasetImplementationKeyValue) datasetMap1.get("datasetImplementation1KeyValue0"));
+    }
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationServiceTest.java
@@ -1,0 +1,100 @@
+package io.metadew.iesi.datatypes.dataset.implementation.inmemory;
+
+import io.metadew.iesi.common.configuration.Configuration;
+import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
+import io.metadew.iesi.datatypes.dataset.Dataset;
+import io.metadew.iesi.datatypes.dataset.DatasetConfiguration;
+import io.metadew.iesi.datatypes.dataset.DatasetKey;
+import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationConfiguration;
+import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationKey;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabel;
+import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabelKey;
+import io.metadew.iesi.datatypes.text.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.metadew.iesi.datatypes.dataset.DatasetBuilder.generateDataset;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryDatasetImplementationServiceTest {
+
+    @BeforeAll
+    static void prepare() {
+        Configuration.getInstance();
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository()
+                .createAllTables();
+    }
+
+    @AfterEach
+    void clearDatabase() {
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository().cleanAllTables();
+    }
+
+    @AfterAll
+    static void teardown() {
+        MetadataRepositoryConfiguration.getInstance()
+                .getDataMetadataRepository().dropAllTables();
+    }
+
+    @Test
+    void testSetDataItemNewKey() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+
+        InMemoryDatasetImplementationService.getInstance()
+                .setDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"),
+                        "key",
+                        new Text("value")
+                );
+
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationId(new DatasetImplementationKey((UUID) datasetMap.get("datasetImplementation0UUID"))))
+                .hasSize(2);
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(new DatasetImplementationKey((UUID) datasetMap.get("datasetImplementation0UUID")), "key000"))
+                .isPresent()
+                .map(InMemoryDatasetImplementationKeyValue::getValue)
+                .get()
+                .isEqualTo("value000");
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(new DatasetImplementationKey((UUID) datasetMap.get("datasetImplementation0UUID")), "key"))
+                .isPresent()
+                .map(InMemoryDatasetImplementationKeyValue::getValue)
+                .get()
+                .isEqualTo("value");
+    }
+
+    @Test
+    void testSetDataItemExistingKey() {
+        Map<String, Object> datasetMap = generateDataset(0, 1, 1, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+
+        InMemoryDatasetImplementationService.getInstance()
+                .setDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"),
+                        "key000",
+                        new Text("value001")
+                );
+
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationId(new DatasetImplementationKey((UUID) datasetMap.get("datasetImplementation0UUID"))))
+                .hasSize(1);
+        assertThat(InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
+                .getByDatasetImplementationIdAndKey(new DatasetImplementationKey((UUID) datasetMap.get("datasetImplementation0UUID")), "key000"))
+                .isPresent()
+                .map(InMemoryDatasetImplementationKeyValue::getValue)
+                .get()
+                .isEqualTo("value001");
+    }
+
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationServiceTest.java
@@ -2,6 +2,9 @@ package io.metadew.iesi.datatypes.dataset.implementation.inmemory;
 
 import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
+import io.metadew.iesi.connection.database.DatabaseHandler;
+import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes.DataTypeHandler;
 import io.metadew.iesi.datatypes.dataset.Dataset;
 import io.metadew.iesi.datatypes.dataset.DatasetConfiguration;
 import io.metadew.iesi.datatypes.dataset.DatasetKey;
@@ -10,19 +13,23 @@ import io.metadew.iesi.datatypes.dataset.implementation.DatasetImplementationKey
 import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabel;
 import io.metadew.iesi.datatypes.dataset.implementation.label.DatasetImplementationLabelKey;
 import io.metadew.iesi.datatypes.text.Text;
+import io.metadew.iesi.script.execution.ExecutionRuntime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static io.metadew.iesi.datatypes.dataset.DatasetBuilder.generateDataset;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 class InMemoryDatasetImplementationServiceTest {
 
@@ -44,6 +51,165 @@ class InMemoryDatasetImplementationServiceTest {
     static void teardown() {
         MetadataRepositoryConfiguration.getInstance()
                 .getDataMetadataRepository().dropAllTables();
+    }
+
+    // public Optional<InMemoryDatasetImplementation> getDatasetImplementation(String name, List<String> labels) {
+
+    @Test
+    void testGetDatasetImplementationByDatasetIdAndLabels() {
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation(new DatasetKey((UUID) datasetMap.get("datasetUUID")), Stream.of("label000", "label001").collect(Collectors.toList())))
+                .hasValue((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation(new DatasetKey((UUID) datasetMap.get("datasetUUID")), Stream.of("label010", "label011").collect(Collectors.toList())))
+                .hasValue((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"));
+    }
+
+    @Test
+    void testGetDatasetImplementationByDatasetIdAndLabelsNoMatch() {
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation(new DatasetKey((UUID) datasetMap.get("datasetUUID")), Stream.of("label000").collect(Collectors.toList())))
+                .isEmpty();
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation(new DatasetKey(UUID.randomUUID()), Stream.of("label010", "label011").collect(Collectors.toList())))
+                .isEmpty();
+    }
+
+    @Test
+    void testGetDatasetImplementationByNameAndLabels() {
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation("dataset0", Stream.of("label000", "label001").collect(Collectors.toList())))
+                .hasValue((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation("dataset0", Stream.of("label010", "label011").collect(Collectors.toList())))
+                .hasValue((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"));
+    }
+
+    @Test
+    void testGetDatasetImplementationByNameAndLabelsNoMatch() {
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 1);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation("dataset0", Stream.of("label000").collect(Collectors.toList())))
+                .isEmpty();
+        assertThat(InMemoryDatasetImplementationService.getInstance().getDatasetImplementation("dataset1", Stream.of("label010", "label011").collect(Collectors.toList())))
+                .isEmpty();
+    }
+
+    @Test
+    void testGetDatasetItem() {
+        DataTypeHandler dataTypeHandler = DataTypeHandler.getInstance();
+        DataTypeHandler dataTypeHandlerSpy = Mockito.spy(dataTypeHandler);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", dataTypeHandlerSpy);
+
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        doReturn(new Text("value000"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value000", executionRuntime);
+        doReturn(new Text("value001"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value001", executionRuntime);
+        doReturn(new Text("value010"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value010", executionRuntime);
+        doReturn(new Text("value011"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value011", executionRuntime);
+
+
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"), "key000", executionRuntime))
+                .hasValue(new Text("value000"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"), "key001", executionRuntime))
+                .hasValue(new Text("value001"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"), "key010", executionRuntime))
+                .hasValue(new Text("value010"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"), "key011", executionRuntime))
+                .hasValue(new Text("value011"));
+
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", (DataTypeHandler) null);
+    }
+
+    @Test
+    void testGetDatasetItems() {
+        DataTypeHandler dataTypeHandler = DataTypeHandler.getInstance();
+        DataTypeHandler dataTypeHandlerSpy = Mockito.spy(dataTypeHandler);
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", dataTypeHandlerSpy);
+
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        doReturn(new Text("value000"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value000", executionRuntime);
+        doReturn(new Text("value001"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value001", executionRuntime);
+        doReturn(new Text("value010"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value010", executionRuntime);
+        doReturn(new Text("value011"))
+                .when(dataTypeHandlerSpy)
+                .resolve("value011", executionRuntime);
+
+
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItems((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"),  executionRuntime))
+                .isEqualTo(
+                        Stream.of(
+                                new AbstractMap.SimpleEntry<String, DataType>("key000", new Text("value000")),
+                                new AbstractMap.SimpleEntry<String, DataType>("key001", new Text("value001"))
+                        ).
+                                collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey,
+                                        AbstractMap.SimpleEntry::getValue))
+                );
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItems((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"), executionRuntime))
+                .isEqualTo(
+                        Stream.of(
+                                new AbstractMap.SimpleEntry<String, DataType>("key010", new Text("value010")),
+                                new AbstractMap.SimpleEntry<String, DataType>("key011", new Text("value011"))
+                        ).
+                                collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey,
+                                        AbstractMap.SimpleEntry::getValue))
+                );
+
+        Whitebox.setInternalState(DataTypeHandler.class, "instance", (DataTypeHandler) null);
+    }
+
+    @Test
+    void testGetDatasetItemsEmpty() {
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 0);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItems((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"),  executionRuntime))
+                .isEmpty();
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItems((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"), executionRuntime))
+                .isEmpty();
+
+    }
+
+    @Test
+    void testGetDatasetItemNoMatch() {
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+
+        Map<String, Object> datasetMap = generateDataset(0, 2, 2, 2);
+        DatasetConfiguration.getInstance().insert((Dataset) datasetMap.get("dataset"));
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation0"), "key100", executionRuntime))
+                .isEmpty();
+        assertThat(InMemoryDatasetImplementationService.getInstance()
+                .getDataItem((InMemoryDatasetImplementation) datasetMap.get("datasetImplementation1"), "key110", executionRuntime))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
**Describe the bug**
When a new data item is added to a dataset implementation, the entire implementation is removed and recreated.

**Expected behavior**
The data item should be updated if it already exists. If the data item does not exist it should be created from scratch.

**Id**
8df23ab