### PR TITLE
allow json response body of api to contain field named 'body'

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/datatypes/dataset/implementation/inmemory/InMemoryDatasetImplementationService.java
@@ -153,13 +153,15 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
             inMemoryDatasetImplementationKeyValue.get().setValue(value.toString());
             InMemoryDatasetImplementationKeyValueConfiguration.getInstance().update(inMemoryDatasetImplementationKeyValue.get());
         } else {
+            InMemoryDatasetImplementationKeyValue newInMemoryDatasetImplementationKeyValue = new InMemoryDatasetImplementationKeyValue(
+                    new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID()),
+                    datasetImplementation.getMetadataKey(),
+                    key,
+                    value.toString()
+            );
+            datasetImplementation.getKeyValues().add(newInMemoryDatasetImplementationKeyValue);
             InMemoryDatasetImplementationKeyValueConfiguration.getInstance()
-                    .insert(new InMemoryDatasetImplementationKeyValue(
-                            new InMemoryDatasetImplementationKeyValueKey(UUID.randomUUID()),
-                            datasetImplementation.getMetadataKey(),
-                            key,
-                            value.toString()
-                    ));
+                    .insert(newInMemoryDatasetImplementationKeyValue);
         }
     }
 
@@ -184,7 +186,7 @@ public class InMemoryDatasetImplementationService extends DatasetImplementationS
             List<String> labels = inMemoryDatasetImplementation.getDatasetImplementationLabels().stream()
                     .map(DatasetImplementationLabel::getValue)
                     .collect(Collectors.toList());
-            labels.add(keyPrefix);
+            labels.add(UUID.randomUUID().toString());
             return createNewDatasetImplementation(inMemoryDatasetImplementation.getDatasetKey(), inMemoryDatasetImplementation.getName(), labels);
         } else {
             return inMemoryDatasetImplementation;


### PR DESCRIPTION
**Describe the bug**
When a API response body is of type json, is saved to a dataset and the json body contains a field called body,  a SQL unique constraint exception is thrown on a label name

**Root cause**
The label 'body' is used twice by the framework. Once to save the entire body, once to save the 'body' field of the body

**Id**
32808d3