### PR TITLE
add text replace instruction

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
@@ -9,6 +9,7 @@ import io.metadew.iesi.script.execution.instruction.data.person.PersonEmail;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonFirstName;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonLastName;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonPhoneNumber;
+import io.metadew.iesi.script.execution.instruction.data.text.TextReplace;
 import io.metadew.iesi.script.execution.instruction.data.text.TextSubstring;
 import io.metadew.iesi.script.execution.instruction.data.time.TimeFormat;
 import io.metadew.iesi.script.execution.instruction.data.time.TimeNow;
@@ -57,6 +58,9 @@ public class DataInstructionRepository {
 
         ListSize listSize = new ListSize(executionRuntime);
         dataInstructions.put(listSize.getKeyword(), listSize);
+
+        TextReplace textReplace = new TextReplace();
+        dataInstructions.put(textReplace.getKeyword(), textReplace);
 
         return dataInstructions;
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -1,0 +1,2 @@
+package io.metadew.iesi.script.execution.instruction.data.text;public class TextReplace {
+}

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -1,2 +1,32 @@
-package io.metadew.iesi.script.execution.instruction.data.text;public class TextReplace {
+package io.metadew.iesi.script.execution.instruction.data.text;
+
+import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
+
+import java.text.MessageFormat;
+
+public class TextReplace implements DataInstruction {
+
+    @Override
+    public String generateOutput(String parameters) {
+
+        String [] args = parameters.split(",");
+        if(args.length == 3){
+            String text = args[0];
+            String first = args[1];
+            String end = args[2];
+            text = text.replaceAll(first,end);
+            return text;
+        }else if (args.length==2) {
+            String text = args[0];
+            String first = args[1];
+            text = text.replaceAll(first, "");
+            return text;
+        } else {
+            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+        }
+    }
+
+    @Override
+    public String getKeyword() { return "text.replace"; }
+
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -1,4 +1,40 @@
 package io.metadew.iesi.script.execution.instruction.data.text;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class TextReplaceTest {
+
+    @Test
+    void textReplace() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("source dexd", textReplace.generateOutput("source text,t,d"));
+    }
+
+    @Test
+    void textReplaceTwo() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("source text", textReplace.generateOutput("source text,f,d"));
+    }
+
+    @Test
+    void textReplaceThree() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("sourcetext", textReplace.generateOutput("source text, ,"));
+    }
+
+    @Test
+    void textReplaceFour() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("source ex", textReplace.generateOutput("source text,t,"));
+    }
+
+    @Test
+    void textReplaceThrowException() {
+        TextReplace textReplace = new TextReplace();
+        assertThrows(IllegalArgumentException.class, () -> textReplace.generateOutput("source text,,"));
+    }
+
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -1,0 +1,4 @@
+package io.metadew.iesi.script.execution.instruction.data.text;
+
+public class TextReplaceTest {
+}


### PR DESCRIPTION
**Description**
Add an data instruction that will take three arguments:
* source text, the original text
* character to be replaced
* character to be used for replacement

The new data instruction, text.replace(\<source text>, \<character to be replaced>, \<character to be used for replacement>) should replace all the 'character to be replaced' in the 'source text' with the 'character to be used for replacement'.

**Examples**
* text.replace("source text", "t",  "d") -> source dexd
* text.replace("source text", "f",  "d") -> source text
* text.replace("source text", " ",  "") -> sourcetext
* text.replace("source text", "t",  "") -> source ex

**Starting point**
* Similar instruction: io.metadew.iesi.script.execution.instruction.data.text.TextSubstring
*  io.metadew.iesi.script.execution.instruction.data.DataInstructionRepository