### PR TITLE
bug: connection parameters are presented as SerialClobs instead of string

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepository.java
@@ -2,6 +2,7 @@ package io.metadew.iesi.server.rest.connection.dto;
 
 import io.metadew.iesi.common.configuration.metadata.repository.MetadataRepositoryConfiguration;
 import io.metadew.iesi.common.configuration.metadata.tables.MetadataTablesConfiguration;
+import io.metadew.iesi.connection.tools.SQLTools;
 import io.metadew.iesi.server.rest.connection.ConnectionFilter;
 import io.metadew.iesi.server.rest.connection.ConnectionFilterOption;
 import io.metadew.iesi.server.rest.dataset.FilterService;
@@ -179,7 +180,7 @@ public class ConnectionDtoRepository extends PaginatedRepository implements ICon
                         cachedRowSet.getString("CONN_PAR_NM"),
                         new ConnectionParameterDto(
                                 cachedRowSet.getString("CONN_PAR_NM"),
-                                cachedRowSet.getString("CONN_PAR_VAL")
+                                SQLTools.getStringFromSQLClob(cachedRowSet, "CONN_PAR_VAL")
                         )
                 );
             }


### PR DESCRIPTION
Make sure that the API returns the String value instead of the SerialClob value

![connections_bug](https://user-images.githubusercontent.com/6872974/122217055-55dad180-cead-11eb-9b30-6d7a4dbc64d8.PNG)
