### PR TITLE
Script Design - Action Type: http.executeRequest - Spelling Mistake

### DIFF
--- a/core/conf/application-action-types.yml
+++ b/core/conf/application-action-types.yml
@@ -808,14 +808,14 @@ iesi:
             subroutine:
             impersonate: false
           headers:
-            description: Additionnal header as key=value pair or dataset
+            description: Additional header as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false
             subroutine:
             impersonate: false
           queryParameters:
-            description: Additionnal query parameters as key=value pair or dataset
+            description: Additional query parameters as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false

--- a/core/java/iesi-core/src/main/resources/application-action-types.yml
+++ b/core/java/iesi-core/src/main/resources/application-action-types.yml
@@ -808,14 +808,14 @@ iesi:
             subroutine:
             impersonate: false
           headers:
-            description: headers
+            description: Additional header as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false
             subroutine:
             impersonate: false
           queryParameters:
-            description: queryParams
+            description: Additional query parameters as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false

--- a/core/java/iesi-core/src/test/resources/application-action-types.yml
+++ b/core/java/iesi-core/src/test/resources/application-action-types.yml
@@ -532,7 +532,7 @@ iesi:
       fwk.dummy:
         className: io.metadew.iesi.script.action.fwk.FwkDummy
         description: Dummy for adding a placeholder step
-        parameters: {}
+        parameters: { }
         status: stable
       fwk.executeScript:
         className: io.metadew.iesi.script.action.fwk.FwkExecuteScript
@@ -754,12 +754,12 @@ iesi:
       fwk.startIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStartIteration
         description: Start an iteration block for the steps
-        parameters: {}
+        parameters: { }
         status: experimental
       fwk.stopIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStopIteration
         description: Stop the iteration block
-        parameters: {}
+        parameters: { }
         status: experimental
       http.executeRequest:
         className: io.metadew.iesi.script.action.http.HttpExecuteRequest
@@ -808,14 +808,14 @@ iesi:
             subroutine:
             impersonate: false
           headers:
-            description: headers
+            description: Additional header as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false
             subroutine:
             impersonate: false
           queryParameters:
-            description: queryParams
+            description: Additional query parameters as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false

--- a/core/java/iesi-core/src/test/resources/application-action-types.yml
+++ b/core/java/iesi-core/src/test/resources/application-action-types.yml
@@ -532,7 +532,7 @@ iesi:
       fwk.dummy:
         className: io.metadew.iesi.script.action.fwk.FwkDummy
         description: Dummy for adding a placeholder step
-        parameters: { }
+        parameters: {}
         status: stable
       fwk.executeScript:
         className: io.metadew.iesi.script.action.fwk.FwkExecuteScript
@@ -754,12 +754,12 @@ iesi:
       fwk.startIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStartIteration
         description: Start an iteration block for the steps
-        parameters: { }
+        parameters: {}
         status: experimental
       fwk.stopIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStopIteration
         description: Stop the iteration block
-        parameters: { }
+        parameters: {}
         status: experimental
       http.executeRequest:
         className: io.metadew.iesi.script.action.http.HttpExecuteRequest

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-action-types.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-action-types.yml
@@ -808,14 +808,14 @@ iesi:
             subroutine:
             impersonate: false
           headers:
-            description: headers
+            description: Additional header as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false
             subroutine:
             impersonate: false
           queryParameters:
-            description: queryParams
+            description: Additional query parameters as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false

--- a/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-action-types.yml
+++ b/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-action-types.yml
@@ -532,7 +532,7 @@ iesi:
       fwk.dummy:
         className: io.metadew.iesi.script.action.fwk.FwkDummy
         description: Dummy for adding a placeholder step
-        parameters: {}
+        parameters: { }
         status: stable
       fwk.executeScript:
         className: io.metadew.iesi.script.action.fwk.FwkExecuteScript
@@ -754,12 +754,12 @@ iesi:
       fwk.startIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStartIteration
         description: Start an iteration block for the steps
-        parameters: {}
+        parameters: { }
         status: experimental
       fwk.stopIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStopIteration
         description: Stop the iteration block
-        parameters: {}
+        parameters: { }
         status: experimental
       http.executeRequest:
         className: io.metadew.iesi.script.action.http.HttpExecuteRequest
@@ -808,14 +808,14 @@ iesi:
             subroutine:
             impersonate: false
           headers:
-            description: headers
+            description: Additional header as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false
             subroutine:
             impersonate: false
           queryParameters:
-            description: queryParams
+            description: Additional query parameters as key=value pair or dataset
             type: string
             mandatory: false
             encrypted: false

--- a/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-action-types.yml
+++ b/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-action-types.yml
@@ -532,7 +532,7 @@ iesi:
       fwk.dummy:
         className: io.metadew.iesi.script.action.fwk.FwkDummy
         description: Dummy for adding a placeholder step
-        parameters: { }
+        parameters: {}
         status: stable
       fwk.executeScript:
         className: io.metadew.iesi.script.action.fwk.FwkExecuteScript
@@ -754,12 +754,12 @@ iesi:
       fwk.startIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStartIteration
         description: Start an iteration block for the steps
-        parameters: { }
+        parameters: {}
         status: experimental
       fwk.stopIteration:
         className: io.metadew.iesi.script.action.fwk.FwkStopIteration
         description: Stop the iteration block
-        parameters: { }
+        parameters: {}
         status: experimental
       http.executeRequest:
         className: io.metadew.iesi.script.action.http.HttpExecuteRequest


### PR DESCRIPTION
Screen: Script Design
Functionality: add action of type "http.executeRequest"

Actual:
- Spelling mistakes in the description for "headers" & "queryparameters" - (Additionnal instead of Additional)

Expected:
- No spelling mistake in the description for "headers" & "queryparameters"

Remark: this is a heavily used actiontype, therefore, logging spellingmistakes in order to be clean & aligned.

![Script_Design_HttpExecuteRequest_SpellingMistake](https://user-images.githubusercontent.com/45843206/123826887-76207c80-d900-11eb-9892-9b1fed8106ee.png)


