### PR TITLE
Connection Creation - HTTP Connection Type - Missing Mandatory Field

### DIFF
--- a/core/conf/application-connection-types.yml
+++ b/core/conf/application-connection-types.yml
@@ -64,6 +64,10 @@ iesi:
         parameters:
           host:
             description: The host name of the server where the endpoints are hosted
+            type: string
+            mandatory: true
+            encrypted: false
+          port:
             description: Set the specific port for the host. In case the default port (80 for http, 443 for HTTPS) this parameter can be omitted
             type: number
             mandatory: false
@@ -71,7 +75,7 @@ iesi:
           baseUrl:
             description: all endpoints hosted at the host start with this specific endpoint
             type: string
-            mandatory: true
+            mandatory: false
             encrypted: false
           tls:
             description: Whether or not the connection to the host is encrypted using TLS

--- a/core/java/iesi-core/src/main/resources/application-connection-types.yml
+++ b/core/java/iesi-core/src/main/resources/application-connection-types.yml
@@ -17,7 +17,7 @@ iesi:
           baseUrl:
             description: all endpoints hosted at the host start with this specific endpoint
             type: string
-            mandatory: true
+            mandatory: false
             encrypted: false
           tls:
             description: Whether or not the connection to the host is encrypted using TLS

--- a/core/java/iesi-core/src/test/resources/application-connection-types.yml
+++ b/core/java/iesi-core/src/test/resources/application-connection-types.yml
@@ -17,7 +17,7 @@ iesi:
           baseUrl:
             description: all endpoints hosted at the host start with this specific endpoint
             type: string
-            mandatory: true
+            mandatory: false
             encrypted: false
           tls:
             description: Whether or not the connection to the host is encrypted using TLS

--- a/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-connection-types.yml
+++ b/core/java/iesi-rest-without-microservices/src/test/resources/application-iesi-connection-types.yml
@@ -1,6 +1,29 @@
 iesi:
   metadata:
     connection-types:
+      http:
+        description: Connection to a server exposing HTTP endpoints
+        parameters:
+          host:
+            description: The host name of the server where the endpoints are hosted
+            type: string
+            mandatory: true
+            encrypted: false
+          port:
+            description: Set the specific port for the host. In case the default port (80 for http, 443 for HTTPS) this parameter can be omitted
+            type: number
+            mandatory: false
+            encrypted: false
+          baseUrl:
+            description: all endpoints hosted at the host start with this specific endpoint
+            type: string
+            mandatory: false
+            encrypted: false
+          tls:
+            description: Whether or not the connection to the host is encrypted using TLS
+            type: boolean
+            mandatory: true
+            encrypted: false
       db.db2:
         description: IBM DB2 Database Connection
         parameters:


### PR DESCRIPTION
Screen: Connections
Functionality: Create connection

**Actual:**
- When selecting type 'http' and add environment - two mandatory parameters are shown: "baseUrl" & "tls"
- Missing mandatory parameter: "host"
- If not provided, connection give error when executed

**Expected:**
- When selecting type 'http' and add environment - three mandatory parameters are shown: "baseUrl" - "tls" - "host"

![Connection_Missing_MandatoryField_Host](https://user-images.githubusercontent.com/45843206/123826174-d105a400-d8ff-11eb-8452-d5360a558138.png)
