### PR TITLE
TextReplace Instruction functionality is not working for special characters.

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -3,35 +3,42 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 
 import java.text.MessageFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TextReplace implements DataInstruction {
+
+    private final static String FIRST_OPERATOR = "text";
+    private final static String SECOND_OPERATOR = "start";
+    private final static String THIRD_OPERATOR = "end";
+    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\"\\s*(?<" + SECOND_OPERATOR + ">.+)\"," +
+            "\"\\s*(?<" + THIRD_OPERATOR + ">.+)\"");
+
+    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\"\\s*(?<" +
+            SECOND_OPERATOR + ">.+)\"");
 
     @Override
     public String generateOutput(String parameters) {
 
-        String [] args = parameters.split(",\\s+");
+        Matcher inputParameterMatcher = THREE_ARGUMENTS_PATTERN.matcher(parameters);
+        Matcher inputParameterMatcherTwoArguments = TWO_ARGUMENTS_PATTERN.matcher(parameters);
 
-        if (args.length == 3){
-            String text = args[0];
-            String first = args[1];
-            String end = args[2];
-            text = text.replace(first,end);
+        if (inputParameterMatcher.find()) {
+            String text = inputParameterMatcher.group(FIRST_OPERATOR);
+            String start = inputParameterMatcher.group(SECOND_OPERATOR);
+            String end = inputParameterMatcher.group(THIRD_OPERATOR);
+            text = text.replace(start, end);
             return text;
-        } else if (args.length == 2) {
-            String text = args[0];
-            String first = args[1];
-            text = text.replace(first, "");
+        } else if(inputParameterMatcherTwoArguments.matches()) {
+            String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
+            String start = inputParameterMatcherTwoArguments.group(SECOND_OPERATOR);
+            text = text.replace(start, "");
             return text;
-        } else if(args.length == 1) {
-            String text = args[0];
-            text = text.replaceAll("\\s","");
-            return text;
-        }
-        else {
-            throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+        }else {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         }
     }
-
     @Override
     public String getKeyword() { return "text.replace"; }
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -34,8 +34,8 @@ public class TextReplace implements DataInstruction {
             text = text.replace(characterToBeReplaced, "");
             return text;
         }else {
-            throw new IllegalArgumentException(MessageFormat.format(
-                    String.format(" Illegal arguments provided to " + this.getKeyword() + " : {0} "), parameters));
+            throw new IllegalArgumentException(
+                    String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
         }
     }
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -9,8 +9,8 @@ import java.util.regex.Pattern;
 public class TextReplace implements DataInstruction {
 
     private final static String FIRST_OPERATOR = "text";
-    private final static String SECOND_OPERATOR = "start";
-    private final static String THIRD_OPERATOR = "end";
+    private final static String SECOND_OPERATOR = "characterToBeReplaced";
+    private final static String THIRD_OPERATOR = "replacementChar";
 
     private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\\s*\"(?<" + FIRST_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + SECOND_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + THIRD_OPERATOR + ">.+)\"\\s*");
 
@@ -24,17 +24,17 @@ public class TextReplace implements DataInstruction {
 
         if (inputParameterMatcher.find()) {
             String text = inputParameterMatcher.group(FIRST_OPERATOR);
-            String start = inputParameterMatcher.group(SECOND_OPERATOR);
-            String end = inputParameterMatcher.group(THIRD_OPERATOR);
-            text = text.replace(start, end);
+            String characterToBeReplaced = inputParameterMatcher.group(SECOND_OPERATOR);
+            String replacementChar = inputParameterMatcher.group(THIRD_OPERATOR);
+            text = text.replace(characterToBeReplaced, replacementChar);
             return text;
         } else if(inputParameterMatcherTwoArguments.matches()) {
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
-            String start = inputParameterMatcherTwoArguments.group(SECOND_OPERATOR);
-            text = text.replace(start, "");
+            String characterToBeReplaced = inputParameterMatcherTwoArguments.group(SECOND_OPERATOR);
+            text = text.replace(characterToBeReplaced, "");
             return text;
         }else {
-            throw new IllegalArgumentException(MessageFormat.format(
+            throw new IllegalArgumentException(String.format(
                     "Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         }
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -9,19 +9,25 @@ public class TextReplace implements DataInstruction {
     @Override
     public String generateOutput(String parameters) {
 
-        String [] args = parameters.split(",");
-        if(args.length == 3){
+        String [] args = parameters.split(",\\s+");
+
+        if (args.length == 3){
             String text = args[0];
             String first = args[1];
             String end = args[2];
-            text = text.replaceAll(first,end);
+            text = text.replace(first,end);
             return text;
-        }else if (args.length==2) {
+        } else if (args.length == 2) {
             String text = args[0];
             String first = args[1];
-            text = text.replaceAll(first, "");
+            text = text.replace(first, "");
             return text;
-        } else {
+        } else if(args.length == 1) {
+            String text = args[0];
+            text = text.replaceAll("\\s","");
+            return text;
+        }
+        else {
             throw new IllegalArgumentException(MessageFormat.format("Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
         }
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -11,10 +11,10 @@ public class TextReplace implements DataInstruction {
     private final static String FIRST_OPERATOR = "text";
     private final static String SECOND_OPERATOR = "start";
     private final static String THIRD_OPERATOR = "end";
-    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\"\\s*(?<" + SECOND_OPERATOR + ">.+)\"," +
-            "\"\\s*(?<" + THIRD_OPERATOR + ">.+)\"");
+    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\\s\"\\s*(?<" + SECOND_OPERATOR + ">.+)\"," +
+            "\\s\"\\s*(?<" + THIRD_OPERATOR + ">.+)\"");
 
-    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\"\\s*(?<" +
+    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\\s\"\\s*(?<" +
             SECOND_OPERATOR + ">.+)\"");
 
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -10,7 +10,7 @@ public class TextReplace implements DataInstruction {
 
     private final static String FIRST_OPERATOR = "text";
     private final static String SECOND_OPERATOR = "characterToBeReplaced";
-    private final static String THIRD_OPERATOR = "replacementChar";
+    private final static String THIRD_OPERATOR = "replacementCharacter";
 
     private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\\s*\"(?<" + FIRST_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + SECOND_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + THIRD_OPERATOR + ">.+)\"\\s*");
 
@@ -25,8 +25,8 @@ public class TextReplace implements DataInstruction {
         if (inputParameterMatcher.find()) {
             String text = inputParameterMatcher.group(FIRST_OPERATOR);
             String characterToBeReplaced = inputParameterMatcher.group(SECOND_OPERATOR);
-            String replacementChar = inputParameterMatcher.group(THIRD_OPERATOR);
-            text = text.replace(characterToBeReplaced, replacementChar);
+            String replacementCharacter = inputParameterMatcher.group(THIRD_OPERATOR);
+            text = text.replace(characterToBeReplaced, replacementCharacter);
             return text;
         } else if(inputParameterMatcherTwoArguments.matches()) {
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
@@ -34,8 +34,8 @@ public class TextReplace implements DataInstruction {
             text = text.replace(characterToBeReplaced, "");
             return text;
         }else {
-            throw new IllegalArgumentException(String.format(
-                    "Illegal arguments provided to " + this.getKeyword() + ": {0}", parameters));
+            throw new IllegalArgumentException(MessageFormat.format(
+                    String.format(" Illegal arguments provided to " + this.getKeyword() + " : {0} "), parameters));
         }
     }
     @Override

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -28,17 +28,20 @@ public class TextReplace implements DataInstruction {
             String replacementCharacter = inputParameterMatcher.group(THIRD_OPERATOR);
             text = text.replace(characterToBeReplaced, replacementCharacter);
             return text;
-        } else if(inputParameterMatcherTwoArguments.matches()) {
+        } else if (inputParameterMatcherTwoArguments.matches()) {
             String text = inputParameterMatcherTwoArguments.group(FIRST_OPERATOR);
             String characterToBeReplaced = inputParameterMatcherTwoArguments.group(SECOND_OPERATOR);
             text = text.replace(characterToBeReplaced, "");
             return text;
-        }else {
+        } else {
             throw new IllegalArgumentException(
                     String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
         }
     }
+
     @Override
-    public String getKeyword() { return "text.replace"; }
+    public String getKeyword() {
+        return "text.replace";
+    }
 
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -2,7 +2,6 @@ package io.metadew.iesi.script.execution.instruction.data.text;
 
 import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
 
-import java.text.MessageFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,8 +33,7 @@ public class TextReplace implements DataInstruction {
             text = text.replace(characterToBeReplaced, "");
             return text;
         } else {
-            throw new IllegalArgumentException(
-                    String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
+            throw new IllegalArgumentException(String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
         }
     }
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplace.java
@@ -11,11 +11,10 @@ public class TextReplace implements DataInstruction {
     private final static String FIRST_OPERATOR = "text";
     private final static String SECOND_OPERATOR = "start";
     private final static String THIRD_OPERATOR = "end";
-    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\\s\"\\s*(?<" + SECOND_OPERATOR + ">.+)\"," +
-            "\\s\"\\s*(?<" + THIRD_OPERATOR + ">.+)\"");
 
-    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("\"(?<" +FIRST_OPERATOR + ">.+)\"," + "\\s\"\\s*(?<" +
-            SECOND_OPERATOR + ">.+)\"");
+    private final static Pattern THREE_ARGUMENTS_PATTERN = Pattern.compile("\\s*\"(?<" + FIRST_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + SECOND_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + THIRD_OPERATOR + ">.+)\"\\s*");
+
+    private final static Pattern TWO_ARGUMENTS_PATTERN = Pattern.compile("\\s*\"(?<" + FIRST_OPERATOR + ">.+)\"\\s*,\\s*\"(?<" + SECOND_OPERATOR + ">.+)\"\\s*");
 
     @Override
     public String generateOutput(String parameters) {

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -67,4 +67,16 @@ class TextReplaceTest {
         assertEquals("source text" , textReplace.generateOutput("\"sour\"e text\", \"\"\", \"c\""));
     }
 
+    @Test
+    void textReplaceInstruction() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("source cexc" , textReplace.generateOutput("     \"source text\"    , \"t\",    \"c\"  "));
+    }
+
+    @Test
+    void textReplaceBySpace() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("12345678", textReplace.generateOutput("\"         12345678\", \" \""));
+    }
+
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -10,31 +10,49 @@ public class TextReplaceTest {
     @Test
     void textReplace() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source dexd", textReplace.generateOutput("source text,t,d"));
+        assertEquals("source dexd", textReplace.generateOutput("source text, t, d"));
     }
 
     @Test
     void textReplaceTwo() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source text", textReplace.generateOutput("source text,f,d"));
+        assertEquals("source text", textReplace.generateOutput("source text, f, d"));
     }
 
     @Test
     void textReplaceThree() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("sourcetext", textReplace.generateOutput("source text, ,"));
+        assertEquals("sourcetext", textReplace.generateOutput("source text,  ,  "));
     }
 
     @Test
     void textReplaceFour() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source ex", textReplace.generateOutput("source text,t,"));
+        assertEquals("source ex", textReplace.generateOutput("source text, t, "));
     }
 
     @Test
     void textReplaceThrowException() {
         TextReplace textReplace = new TextReplace();
-        assertThrows(IllegalArgumentException.class, () -> textReplace.generateOutput("source text,,"));
+        assertThrows(IllegalArgumentException.class, () -> textReplace.generateOutput("Some, String, For, Illegal, Exception"));
+    }
+
+    @Test
+    void textReplaceWithSpecialCharacter() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("01234  05678", textReplace.generateOutput("+1234  +5678, +, 0"));
+    }
+
+    @Test
+    void textReplaceByEmptySpace() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("12345678", textReplace.generateOutput("+12345678, +, "));
+    }
+
+    @Test
+    void textReplaceByEmptySpaceWithTwoArg() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("12345678", textReplace.generateOutput("+12+345+678, +"));
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -10,25 +10,25 @@ class TextReplaceTest {
     @Test
     void textReplace() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source dexd", textReplace.generateOutput("\"source text\",\"t\",\"d\""));
+        assertEquals("source dexd", textReplace.generateOutput("\"source text\", \"t\", \"d\""));
     }
 
     @Test
     void textReplaceTwo() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source text", textReplace.generateOutput("\"source text\",\"f\",\"d\""));
+        assertEquals("source text", textReplace.generateOutput("\"source text\", \"f\", \"d\""));
     }
 
     @Test
     void textReplaceThree() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("sourcetext", textReplace.generateOutput("\"source text\",\" \""));
+        assertEquals("sourcetext", textReplace.generateOutput("\"source text\", \" \""));
     }
 
     @Test
     void textReplaceFour() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source ex", textReplace.generateOutput("\"source text\",\"t\""));
+        assertEquals("source ex", textReplace.generateOutput("\"source text\", \"t\""));
     }
 
     @Test
@@ -40,25 +40,25 @@ class TextReplaceTest {
     @Test
     void textReplaceWithSpecialCharacter() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("01234  05678", textReplace.generateOutput("\"+1234  +5678\",\"+\",\"0\""));
+        assertEquals("01234  05678", textReplace.generateOutput("\"+1234  +5678\", \"+\", \"0\""));
     }
 
     @Test
     void textReplaceByEmptySpace() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("12345678", textReplace.generateOutput("\"+12345678\",\"+\""));
+        assertEquals("12345678", textReplace.generateOutput("\"+12345678\", \"+\""));
     }
 
     @Test
     void textReplaceByEmptySpaceWithTwoArg() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("12345678", textReplace.generateOutput("\"+12+345+678\",\"+\""));
+        assertEquals("12345678", textReplace.generateOutput("\"+12+345+678\", \"+\""));
     }
 
     @Test
     void textReplaceByComma() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("1234.567.8", textReplace.generateOutput("\"1234,567,8\",\",\",\".\""));
+        assertEquals("1234.567.8", textReplace.generateOutput("\"1234,567,8\", \",\", \".\""));
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -5,54 +5,60 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TextReplaceTest {
+class TextReplaceTest {
 
     @Test
     void textReplace() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source dexd", textReplace.generateOutput("source text, t, d"));
+        assertEquals("source dexd", textReplace.generateOutput("\"source text\",\"t\",\"d\""));
     }
 
     @Test
     void textReplaceTwo() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source text", textReplace.generateOutput("source text, f, d"));
+        assertEquals("source text", textReplace.generateOutput("\"source text\",\"f\",\"d\""));
     }
 
     @Test
     void textReplaceThree() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("sourcetext", textReplace.generateOutput("source text,  ,  "));
+        assertEquals("sourcetext", textReplace.generateOutput("\"source text\",\" \""));
     }
 
     @Test
     void textReplaceFour() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("source ex", textReplace.generateOutput("source text, t, "));
+        assertEquals("source ex", textReplace.generateOutput("\"source text\",\"t\""));
     }
 
     @Test
     void textReplaceThrowException() {
         TextReplace textReplace = new TextReplace();
-        assertThrows(IllegalArgumentException.class, () -> textReplace.generateOutput("Some, String, For, Illegal, Exception"));
+        assertThrows(IllegalArgumentException.class, () -> textReplace.generateOutput("Some String, For, Illegal, Exception"));
     }
 
     @Test
     void textReplaceWithSpecialCharacter() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("01234  05678", textReplace.generateOutput("+1234  +5678, +, 0"));
+        assertEquals("01234  05678", textReplace.generateOutput("\"+1234  +5678\",\"+\",\"0\""));
     }
 
     @Test
     void textReplaceByEmptySpace() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("12345678", textReplace.generateOutput("+12345678, +, "));
+        assertEquals("12345678", textReplace.generateOutput("\"+12345678\",\"+\""));
     }
 
     @Test
     void textReplaceByEmptySpaceWithTwoArg() {
         TextReplace textReplace = new TextReplace();
-        assertEquals("12345678", textReplace.generateOutput("+12+345+678, +"));
+        assertEquals("12345678", textReplace.generateOutput("\"+12+345+678\",\"+\""));
+    }
+
+    @Test
+    void textReplaceByComma() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("1234.567.8", textReplace.generateOutput("\"1234,567,8\",\",\",\".\""));
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextReplaceTest.java
@@ -61,4 +61,10 @@ class TextReplaceTest {
         assertEquals("1234.567.8", textReplace.generateOutput("\"1234,567,8\", \",\", \".\""));
     }
 
+    @Test
+    void textReplaceByQuote() {
+        TextReplace textReplace = new TextReplace();
+        assertEquals("source text" , textReplace.generateOutput("\"sour\"e text\", \"\"\", \"c\""));
+    }
+
 }


### PR DESCRIPTION
TextReplace Instruction is not working for some of the special characters like ., +, *, ?, ^, $, (, ), [, ], {, }, |, \.

![Screenshot (27)](https://user-images.githubusercontent.com/81413098/124612332-db8be480-de8f-11eb-9f7d-c2a6a740975a.png)


