### PR TITLE
Script Design - Action Type: http.executeRequest- Remove proxy value

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/cli/CliExecuteCommand.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/cli/CliExecuteCommand.java
@@ -6,6 +6,7 @@ import io.metadew.iesi.connection.host.ShellCommandSettings;
 import io.metadew.iesi.connection.operation.ConnectionOperation;
 import io.metadew.iesi.connection.tools.HostConnectionTools;
 import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.text.Text;
 import io.metadew.iesi.metadata.configuration.connection.ConnectionConfiguration;
 import io.metadew.iesi.metadata.definition.connection.Connection;
@@ -109,7 +110,7 @@ public class CliExecuteCommand extends ActionTypeExecution {
 
     private String convertSetRuntimeVariablesMode(DataType setRuntimeVariablesMode) {
         // TODO: make optional
-        if (setRuntimeVariablesMode == null) {
+        if (setRuntimeVariablesMode == null || setRuntimeVariablesMode instanceof Null) {
             return "";
         }
         if (setRuntimeVariablesMode instanceof Text) {
@@ -122,7 +123,7 @@ public class CliExecuteCommand extends ActionTypeExecution {
     }
 
     private String convertConnectionName(DataType connectionName) {
-        if (connectionName == null) {
+        if (connectionName == null || connectionName instanceof Null) {
             return "localhost";
         } else if (connectionName instanceof Text) {
             return connectionName.toString();
@@ -135,7 +136,7 @@ public class CliExecuteCommand extends ActionTypeExecution {
 
     private String convertSetRuntimeVariablesPrefix(DataType setRuntimeVariablesPrefix) {
         // TODO: make optional
-        if (setRuntimeVariablesPrefix == null) {
+        if (setRuntimeVariablesPrefix == null || setRuntimeVariablesPrefix instanceof Null) {
             return "";
         }
         if (setRuntimeVariablesPrefix instanceof Text) {
@@ -148,7 +149,7 @@ public class CliExecuteCommand extends ActionTypeExecution {
     }
 
     private boolean convertSetRuntimeVariables(DataType setRuntimeVariables) {
-        if (setRuntimeVariables == null) {
+        if (setRuntimeVariables == null || setRuntimeVariables instanceof Null) {
             return false;
         }
         if (setRuntimeVariables instanceof Text) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataOutputDataset.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataOutputDataset.java
@@ -2,6 +2,7 @@ package io.metadew.iesi.script.action.data;
 
 import io.metadew.iesi.datatypes.DataType;
 import io.metadew.iesi.datatypes.DataTypeHandler;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.array.Array;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationService;
@@ -100,7 +101,7 @@ public class DataOutputDataset extends ActionTypeExecution {
 
 
     private boolean convertOnScreen(DataType onScreen) {
-        if (onScreen == null) {
+        if (onScreen == null || onScreen instanceof Null) {
             return false;
         } else if (onScreen instanceof Text) {
             return onScreen.toString().equalsIgnoreCase("y");

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataSetDatasetConnection.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/data/DataSetDatasetConnection.java
@@ -2,6 +2,7 @@ package io.metadew.iesi.script.action.data;
 
 import io.metadew.iesi.datatypes.DataType;
 import io.metadew.iesi.datatypes.DataTypeHandler;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.array.Array;
 import io.metadew.iesi.datatypes.dataset.Dataset;
 import io.metadew.iesi.datatypes.dataset.DatasetConfiguration;
@@ -127,7 +128,7 @@ public class DataSetDatasetConnection extends ActionTypeExecution {
     }
 
     private String convertDatasetType(DataType datasetType) {
-        if (datasetType == null) {
+        if (datasetType == null || datasetType instanceof Null) {
             return "";
         }
         if (!(datasetType instanceof Text)) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/fwk/FwkSetIteration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/fwk/FwkSetIteration.java
@@ -1,6 +1,7 @@
 package io.metadew.iesi.script.action.fwk;
 
 import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.text.Text;
 import io.metadew.iesi.metadata.definition.Iteration;
 import io.metadew.iesi.script.action.ActionTypeExecution;
@@ -60,7 +61,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private boolean convertIterationInterrupt(DataType iterationInterrupt) {
         // TODO: remove if different class for every iteration variable
-        if (iterationInterrupt == null) {
+        if (iterationInterrupt == null || iterationInterrupt instanceof Null) {
             return false;
         } else if (iterationInterrupt instanceof Text) {
             return iterationInterrupt.toString().equalsIgnoreCase("y");
@@ -73,7 +74,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationCondition(DataType iterationCondition) {
         // TODO: remove if different class for every iteration variable
-        if (iterationCondition == null) {
+        if (iterationCondition == null || iterationCondition instanceof Null) {
             return null;
         } else if (iterationCondition instanceof Text) {
             return iterationCondition.toString();
@@ -86,7 +87,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationStep(DataType iterationStep) {
         // TODO: remove if different class for every iteration variable
-        if (iterationStep == null) {
+        if (iterationStep == null || iterationStep instanceof Null) {
             return null;
         } else if (iterationStep instanceof Text) {
             return iterationStep.toString();
@@ -99,7 +100,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationTo(DataType iterationTo) {
         // TODO: remove if different class for every iteration variable
-        if (iterationTo == null) {
+        if (iterationTo == null || iterationTo instanceof Null) {
             return null;
         } else if (iterationTo instanceof Text) {
             return iterationTo.toString();
@@ -112,7 +113,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationFrom(DataType iterationFrom) {
         // TODO: remove if different class for every iteration variable
-        if (iterationFrom == null) {
+        if (iterationFrom == null || iterationFrom instanceof Null) {
             return null;
         } else if (iterationFrom instanceof Text) {
             return iterationFrom.toString();
@@ -125,7 +126,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationValues(DataType iterationValues) {
         // TODO: remove if different class for every iteration variable
-        if (iterationValues == null) {
+        if (iterationValues == null || iterationValues instanceof Null) {
             return null;
         } else if (iterationValues instanceof Text) {
             return iterationValues.toString();
@@ -138,7 +139,7 @@ public class FwkSetIteration extends ActionTypeExecution {
 
     private String convertIterationList(DataType iterationList) {
         // TODO: remove if different class for every iteration variable
-        if (iterationList == null) {
+        if (iterationList == null || iterationList instanceof Null) {
             return null;
         } else if (iterationList instanceof Text) {
             return iterationList.toString();

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -237,6 +237,9 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         if (connectionName == null) {
             return null;
         } else if (connectionName instanceof Text) {
+            if(((Text) connectionName).getString().isEmpty()){
+                return null;
+            }
             return ConnectionConfiguration.getInstance()
                     .get(new ConnectionKey(((Text) connectionName).getString(), getExecutionControl().getEnvName()))
                     .map(ProxyConnection::from)

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -8,6 +8,7 @@ import io.metadew.iesi.connection.http.request.HttpRequestService;
 import io.metadew.iesi.connection.http.response.HttpResponse;
 import io.metadew.iesi.connection.http.response.HttpResponseService;
 import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.array.Array;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationService;
@@ -130,7 +131,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
 
 
     private List<HttpHeader> convertHeaderParameters(DataType dataType) {
-        if (dataType == null) {
+        if (dataType == null || dataType instanceof Null) {
             return new ArrayList<>();
         } else if (dataType instanceof Text) {
             return Arrays.stream(dataType.toString().split(","))
@@ -152,7 +153,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private List<HttpQueryParameter> convertHttpQueryParameters(DataType dataType) {
-        if (dataType == null) {
+        if (dataType == null || dataType instanceof Null) {
             return new ArrayList<>();
         } else if (dataType instanceof Text) {
             return Arrays.stream(dataType.toString().split(","))
@@ -204,7 +205,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private List<String> convertExpectStatusCodes(DataType expectedStatusCodes) {
-        if (expectedStatusCodes == null) {
+        if (expectedStatusCodes == null || expectedStatusCodes instanceof Null) {
             return null;
         }
         if (expectedStatusCodes instanceof Text) {
@@ -234,12 +235,9 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private ProxyConnection convertProxyName(DataType connectionName) {
-        if (connectionName == null) {
+        if (connectionName == null || connectionName instanceof Null) {
             return null;
         } else if (connectionName instanceof Text) {
-            if(((Text) connectionName).getString().isEmpty()){
-                return null;
-            }
             return ConnectionConfiguration.getInstance()
                     .get(new ConnectionKey(((Text) connectionName).getString(), getExecutionControl().getEnvName()))
                     .map(ProxyConnection::from)
@@ -263,7 +261,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private InMemoryDatasetImplementation convertOutputDatasetReferenceName(DataType outputDatasetReferenceName) {
-        if (outputDatasetReferenceName == null) {
+        if (outputDatasetReferenceName == null || outputDatasetReferenceName instanceof Null) {
             return null;
         } else if (outputDatasetReferenceName instanceof Text) {
             return getExecutionControl().getExecutionRuntime()

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/socket/SocketTransmitMessage.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/socket/SocketTransmitMessage.java
@@ -3,6 +3,7 @@ package io.metadew.iesi.script.action.socket;
 import io.metadew.iesi.common.configuration.Configuration;
 import io.metadew.iesi.connection.network.SocketConnection;
 import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes._null.Null;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementation;
 import io.metadew.iesi.datatypes.dataset.implementation.inmemory.InMemoryDatasetImplementationService;
 import io.metadew.iesi.datatypes.text.Text;
@@ -57,7 +58,7 @@ public class SocketTransmitMessage extends ActionTypeExecution {
     }
 
     private Integer convertTimeout(DataType timeout) {
-        if (timeout == null) {
+        if (timeout == null || timeout instanceof Null) {
             return null;
         } else if (timeout instanceof Text) {
             try {
@@ -73,7 +74,7 @@ public class SocketTransmitMessage extends ActionTypeExecution {
     }
 
     private InMemoryDatasetImplementation convertOutputDataset(DataType dataset) {
-        if (dataset == null) {
+        if (dataset == null || dataset instanceof Null) {
             return null;
         } else if (dataset instanceof Text) {
             return getExecutionControl().getExecutionRuntime().getDataset(((Text) dataset).getString())


### PR DESCRIPTION
Screen: Scripts
Functionality: Add action of type: http.executeRequest to script - field "Proxy"

**Actual:**
- Incorrect behavior when adding & removing a value for the parameter "Proxy" (optional field)

Steps to reproduce:
- Empty value for field Proxy - Save script
- Add value for field Proxy - Save script
- Remove value for field Proxy - Save script
- Execute script

Error: http.executeRequest does not accept class io.metadew.iesi.datatypes._null.Null as type for proxy connection name

**Expected:**
- Since "Proxy" is an optional field, it may not impact the execution when provided an empty value.

**Starting point
java\io\metadew\iesi\script\action\http\HttpExecuteRequest.java
