### PR TITLE
Component Design - Load OpenAPI Documentation - version format error

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
@@ -1,6 +1,5 @@
 package io.metadew.iesi.openapi;
 
-import com.sun.deploy.util.StringUtils;
 import io.metadew.iesi.metadata.definition.component.Component;
 import io.metadew.iesi.metadata.definition.component.ComponentParameter;
 import io.metadew.iesi.metadata.definition.component.ComponentVersion;
@@ -40,7 +39,7 @@ public class ComponentParser implements Parser<Component> {
         String connectionName = openAPI.getInfo().getTitle();
         Long componentVersion;
         try {
-            componentVersion = Long.parseLong(Arrays.stream(StringUtils.splitString(openAPI.getInfo().getVersion(),".")).findFirst().get());
+            componentVersion = Long.parseLong(Arrays.stream(splitString(openAPI.getInfo().getVersion(),".")).findFirst().get());
         } catch (NumberFormatException numberFormatException) {
             throw new SwaggerParserException(Collections.singletonList("The version should be a number"));
         }
@@ -89,5 +88,14 @@ public class ComponentParser implements Parser<Component> {
                 componentParameters,
                 new ArrayList<>());
 
+    }
+
+    public static String[] splitString(String var0, String var1) {
+        StringTokenizer var2 = new StringTokenizer(var0, var1);
+        String[] var3 = new String[var2.countTokens()];
+        for(int var4 = 0; var4 < var3.length; ++var4) {
+            var3[var4] = var2.nextToken();
+        }
+        return var3;
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
@@ -14,7 +14,10 @@ import io.swagger.v3.oas.models.Paths;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 
@@ -39,7 +42,7 @@ public class ComponentParser implements Parser<Component> {
         String connectionName = openAPI.getInfo().getTitle();
         Long componentVersion;
         try {
-            componentVersion = Long.parseLong(Arrays.stream(splitString(openAPI.getInfo().getVersion(),".")).findFirst().get());
+            componentVersion = Long.parseLong(openAPI.getInfo().getVersion().split("\\.")[0]);
         } catch (NumberFormatException numberFormatException) {
             throw new SwaggerParserException(Collections.singletonList("The version should be a number"));
         }
@@ -88,14 +91,5 @@ public class ComponentParser implements Parser<Component> {
                 componentParameters,
                 new ArrayList<>());
 
-    }
-
-    public static String[] splitString(String var0, String var1) {
-        StringTokenizer var2 = new StringTokenizer(var0, var1);
-        String[] var3 = new String[var2.countTokens()];
-        for(int var4 = 0; var4 < var3.length; ++var4) {
-            var3[var4] = var2.nextToken();
-        }
-        return var3;
     }
 }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/openapi/ComponentParser.java
@@ -1,5 +1,6 @@
 package io.metadew.iesi.openapi;
 
+import com.sun.deploy.util.StringUtils;
 import io.metadew.iesi.metadata.definition.component.Component;
 import io.metadew.iesi.metadata.definition.component.ComponentParameter;
 import io.metadew.iesi.metadata.definition.component.ComponentVersion;
@@ -14,10 +15,7 @@ import io.swagger.v3.oas.models.Paths;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 
@@ -42,7 +40,7 @@ public class ComponentParser implements Parser<Component> {
         String connectionName = openAPI.getInfo().getTitle();
         Long componentVersion;
         try {
-            componentVersion = Long.parseLong(openAPI.getInfo().getVersion());
+            componentVersion = Long.parseLong(Arrays.stream(StringUtils.splitString(openAPI.getInfo().getVersion(),".")).findFirst().get());
         } catch (NumberFormatException numberFormatException) {
             throw new SwaggerParserException(Collections.singletonList("The version should be a number"));
         }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/openapi/ComponentParserTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/openapi/ComponentParserTest.java
@@ -133,7 +133,7 @@ class ComponentParserTest {
     @Test
     void createComponentWithStringVersion() {
         List<String> messages = Collections.singletonList("The version should be a number");
-        openAPI.getInfo().setVersion("1.1-SNAPSHOT");
+        openAPI.getInfo().setVersion("SNAPSHOT-1.1");
 
         SwaggerParserException exception = assertThrows(SwaggerParserException.class, () -> ComponentParser.getInstance().parse(openAPI));
         assertThat(exception.getMessages()).isEqualTo(messages);

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/openapi/ComponentParserTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/openapi/ComponentParserTest.java
@@ -7,9 +7,7 @@ import io.metadew.iesi.metadata.definition.component.key.ComponentKey;
 import io.metadew.iesi.metadata.definition.component.key.ComponentParameterKey;
 import io.metadew.iesi.metadata.definition.component.key.ComponentVersionKey;
 import io.metadew.iesi.metadata.tools.IdentifierTools;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,5 +135,53 @@ class ComponentParserTest {
 
         SwaggerParserException exception = assertThrows(SwaggerParserException.class, () -> ComponentParser.getInstance().parse(openAPI));
         assertThat(exception.getMessages()).isEqualTo(messages);
+    }
+
+    @Test
+    void createComponentWithLongVersion() {
+        Paths paths = new Paths();
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new Operation()
+                .description(null)
+                .operationId("operationId"));
+        paths.addPathItem("name", pathItem);
+
+        openAPI.setPaths(paths);
+        openAPI.getInfo().setVersion("1");
+
+        List<Component> components = ComponentParser.getInstance().parse(openAPI);
+        assertThat(components.get(0).getVersion().getMetadataKey().getComponentKey().getVersionNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void createComponentWithSemanticVersion() {
+        Paths paths = new Paths();
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new Operation()
+                .description(null)
+                .operationId("operationId"));
+        paths.addPathItem("name", pathItem);
+
+        openAPI.setPaths(paths);
+        openAPI.getInfo().setVersion("11.2.3");
+
+        List<Component> components = ComponentParser.getInstance().parse(openAPI);
+        assertThat(components.get(0).getVersion().getMetadataKey().getComponentKey().getVersionNumber()).isEqualTo(11);
+    }
+
+    @Test
+    void testComponentWithSemanticVersion() {
+        Paths paths = new Paths();
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(new Operation()
+                .description(null)
+                .operationId("operationId"));
+        paths.addPathItem("name", pathItem);
+
+        openAPI.setPaths(paths);
+        openAPI.getInfo().setVersion("1.2.3");
+
+        List<Component> components = ComponentParser.getInstance().parse(openAPI);
+        assertThat(components.get(0).getVersion().getMetadataKey().getComponentKey().getVersionNumber()).isNotEqualTo(1.2);
     }
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoResourceAssembler.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoResourceAssembler.java
@@ -3,16 +3,15 @@ package io.metadew.iesi.server.rest.connection.dto;
 import io.metadew.iesi.metadata.definition.connection.Connection;
 import io.metadew.iesi.metadata.definition.connection.ConnectionParameter;
 import io.metadew.iesi.server.rest.connection.ConnectionsController;
-import io.metadew.iesi.server.rest.environment.EnvironmentsController;
 import org.modelmapper.ModelMapper;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+import java.util.stream.Stream;
 
 @Component
 public class ConnectionDtoResourceAssembler extends RepresentationModelAssemblerSupport<Connection, ConnectionDto> {
@@ -26,7 +25,29 @@ public class ConnectionDtoResourceAssembler extends RepresentationModelAssembler
 
     @Override
     public ConnectionDto toModel(Connection connection) {
-        throw new RuntimeException("Unsupported operation");
+        return new ConnectionDto(
+                connection.getMetadataKey().getName(),
+                connection.getType(),
+                connection.getDescription(),
+                toConnectionEnvironmentDto(connection.getParameters())
+        );
+    }
+
+    public Set<ConnectionEnvironmentDto> toConnectionEnvironmentDto(List<ConnectionParameter> parameters) {
+        Set<ConnectionParameterDto> connectionParameterDtos = new HashSet<>();
+        String environment = null;
+        for (ConnectionParameter connectionParameter : parameters) {
+            if (environment == null) {
+                environment = connectionParameter.getMetadataKey().getConnectionKey().getEnvironmentKey().getName();
+            }
+            connectionParameterDtos.add(new ConnectionParameterDto(connectionParameter.getName(),
+                    connectionParameter.getValue()));
+        }
+        return Stream.of(new ConnectionEnvironmentDto(environment, connectionParameterDtos)).collect(Collectors.toSet());
+    }
+
+    public List<ConnectionDto> toModel(List<Connection> connections) {
+        return connections.stream().map(this::toModel).collect(Collectors.toList());
     }
 
     public ConnectionDto convertToDto(ConnectionDto connectionDto) {

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/openapi/dto/TransformResultDtoResourceAssembler.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/openapi/dto/TransformResultDtoResourceAssembler.java
@@ -28,8 +28,7 @@ public class TransformResultDtoResourceAssembler extends RepresentationModelAsse
 
     private TransformResultDto convertToDto(TransformResult transformResult) {
         return new TransformResultDto(
-                transformResult.getConnections().stream()
-                        .map(connection -> connectionDtoResourceAssembler.toModel(connection)).collect(Collectors.toList()),
+                connectionDtoResourceAssembler.toModel(transformResult.getConnections()),
                 transformResult.getComponents().stream()
                         .map(component -> componentDtoResourceAssembler.toModel(component)).collect(Collectors.toList()),
                 transformResult.getTitle(),


### PR DESCRIPTION
**Describe the bug**
Screen: Components
Functionality: Design components by using the 'load openAPI documentation'-functionality
Dummy file: use the openapi3.yml for testing purposes

**To Reproduce**
Steps to reproduce the behavior:
1. go to 'Components'- screen
2. click on 'Load OpenAPI documentation'
3. Upload the openapi3.yml by using 'Choose a file' functionality
4. Click on validate

**Expected behavior**
Component(s) draft and/or error display gets shown

**Actual behavior**
Errorcode: **Error: {"errorCode":"400","error":"Something is wrong in your documentation","message":"We found the following errors : \n - The version should be a number \n"}**

while correct standard is applied (openAPI3)

If version is correct then also getting Unsupported operation Exception.

![Load_OpenAPI_Bug_2_BO_Error](https://user-images.githubusercontent.com/45843206/126988562-a0d2bd3a-f959-449c-bfc3-afff13957641.jpg)

