### PR TITLE
allow number formatting

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/DataInstructionRepository.java
@@ -5,6 +5,7 @@ import io.metadew.iesi.script.execution.ExecutionRuntime;
 import io.metadew.iesi.script.execution.instruction.data.belgium.BelgiumNationalRegisterNumber;
 import io.metadew.iesi.script.execution.instruction.data.date.*;
 import io.metadew.iesi.script.execution.instruction.data.number.NumberBetween;
+import io.metadew.iesi.script.execution.instruction.data.number.NumberFormat;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonEmail;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonFirstName;
 import io.metadew.iesi.script.execution.instruction.data.person.PersonLastName;
@@ -61,6 +62,9 @@ public class DataInstructionRepository {
 
         TextReplace textReplace = new TextReplace();
         dataInstructions.put(textReplace.getKeyword(), textReplace);
+
+        NumberFormat numberFormat = new NumberFormat();
+        dataInstructions.put(numberFormat.getKeyword(), numberFormat);
 
         return dataInstructions;
     }

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
@@ -1,0 +1,38 @@
+package io.metadew.iesi.script.execution.instruction.data.number;
+
+import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NumberFormat implements DataInstruction {
+
+    private final static String NUMBER = "number";
+    private final static String FORMAT = "format";
+
+    private final static Pattern PATTERN = Pattern.compile("\\s*\"(?<" + NUMBER + ">.+)\"\\s*,\\s*\"(?<" + FORMAT + ">.+)\"");
+
+    @Override
+    public String generateOutput(String parameters) {
+        Matcher inputParameter = PATTERN.matcher(parameters);
+        if (inputParameter.find()) {
+            try {
+                long number = Long.parseLong(inputParameter.group(NUMBER));
+                String format = inputParameter.group(FORMAT);
+                String output = String.format(format, number);
+                return output;
+            } catch (NumberFormatException e) {
+                throw new NumberFormatException("String cannot be converted to number");
+            }
+        }
+        else {
+            throw new IllegalArgumentException(String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
+        }
+    }
+
+    @Override
+    public String getKeyword() {
+        return "number.format";
+    }
+
+}

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
@@ -10,7 +10,7 @@ public class NumberFormat implements DataInstruction {
     private final static String NUMBER = "number";
     private final static String FORMAT = "format";
 
-    private final static Pattern PATTERN = Pattern.compile("\\s*\"(?<" + NUMBER + ">.+)\"\\s*,\\s*\"(?<" + FORMAT + ">.+)\"");
+    private final static Pattern PATTERN = Pattern.compile("\\s*\"?(?<" + NUMBER + ">.+?)\"?\\s*,\\s*\"(?<" + FORMAT + ">.+)\"");
 
     @Override
     public String generateOutput(String parameters) {

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormat.java
@@ -19,13 +19,11 @@ public class NumberFormat implements DataInstruction {
             try {
                 long number = Long.parseLong(inputParameter.group(NUMBER));
                 String format = inputParameter.group(FORMAT);
-                String output = String.format(format, number);
-                return output;
+                return String.format(format, number);
             } catch (NumberFormatException e) {
                 throw new NumberFormatException("String cannot be converted to number");
             }
-        }
-        else {
+        } else {
             throw new IllegalArgumentException(String.format("Illegal arguments provided to %s:%s", this.getKeyword(), parameters));
         }
     }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
@@ -10,55 +10,91 @@ class NumberFormatTest {
     @Test
     void numberFormat() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("|00000000000000000093|", numberFormat.generateOutput("\"93\", \"|%020d|\""));
+        assertEquals("00000000000000000093", numberFormat.generateOutput("\"93\", \"%020d\""));
     }
 
     @Test
     void numberFormatWithWidth() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("|                  93|", numberFormat.generateOutput("\"93\", \"|%20d|\""));
+        assertEquals("                  93", numberFormat.generateOutput("\"93\", \"%20d\""));
     }
 
     @Test
     void numberFormatWithLeftJustifyingWidth() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("|93                  |", numberFormat.generateOutput("\"93\", \"|%-20d|\""));
+        assertEquals("93                  ", numberFormat.generateOutput("\"93\", \"%-20d\""));
     }
 
     @Test
     void numberFormatWithComma() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("|10,000,000|", numberFormat.generateOutput("\"10000000\", \"|%,d|\""));
+        assertEquals("10,000,000", numberFormat.generateOutput("\"10000000\", \"%,d\""));
     }
 
     @Test
     void numberFormatWithNegative() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("|(25)|", numberFormat.generateOutput("\"-25\", \"|%(d|\""));
+        assertEquals("(25)", numberFormat.generateOutput("\"-25\", \"%(d\""));
     }
 
     @Test
     void numberFormatThrowNumberFormat() {
         NumberFormat numberFormat = new NumberFormat();
-        assertThrows(NumberFormatException.class, () -> numberFormat.generateOutput("\"25a\", \"|%d|\""));
+        assertThrows(NumberFormatException.class, () -> numberFormat.generateOutput("\"25a\", \"%d\""));
     }
 
     @Test
     void numberFormatThrowIllegalArgument() {
         NumberFormat numberFormat = new NumberFormat();
-        assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, |%d|"));
+        assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, %d"));
     }
 
     @Test
-    void numberFormatWithoutMod() {
+    void numberFormatWithMod() {
         NumberFormat numberFormat = new NumberFormat();
-        assertEquals("00000000000000000093", numberFormat.generateOutput("\"93\", \"%020d\""));
+        assertEquals("|00000000000000000093|", numberFormat.generateOutput("\"93\", \"|%020d|\""));
     }
 
     @Test
     void numberFormatWithoutDoubleQuotes() {
         NumberFormat numberFormat = new NumberFormat();
         assertEquals("00000000000000000093", numberFormat.generateOutput("93, \"%020d\""));
+    }
+
+    @Test
+    void numberFormatWithWidthWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("                  93", numberFormat.generateOutput("93, \"%20d\""));
+    }
+
+    @Test
+    void numberFormatWithLeftJustifyingWidthWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("93                  ", numberFormat.generateOutput("93, \"%-20d\""));
+    }
+
+    @Test
+    void numberFormatWithCommaWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("10,000,000", numberFormat.generateOutput("10000000, \"%,d\""));
+    }
+
+    @Test
+    void numberFormatWithNegativeWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("(25)", numberFormat.generateOutput("-25, \"%(d\""));
+    }
+
+    @Test
+    void numberFormatThrowNumberFormatWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertThrows(NumberFormatException.class, () -> numberFormat.generateOutput("25a, \"%d\""));
+    }
+
+    @Test
+    void numberFormatThrowIllegalArgumentWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, %d"));
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NumberFormatTest {
+class NumberFormatTest {
 
     @Test
     void numberFormat() {
@@ -14,37 +14,37 @@ public class NumberFormatTest {
     }
 
     @Test
-    void numberFormatWithWidth(){
+    void numberFormatWithWidth() {
         NumberFormat numberFormat = new NumberFormat();
         assertEquals("|                  93|", numberFormat.generateOutput("\"93\", \"|%20d|\""));
     }
 
     @Test
-    void numberFormatWithLeftJustifyingWidth(){
+    void numberFormatWithLeftJustifyingWidth() {
         NumberFormat numberFormat = new NumberFormat();
         assertEquals("|93                  |", numberFormat.generateOutput("\"93\", \"|%-20d|\""));
     }
 
     @Test
-    void numberFormatWithComma(){
+    void numberFormatWithComma() {
         NumberFormat numberFormat = new NumberFormat();
         assertEquals("|10,000,000|", numberFormat.generateOutput("\"10000000\", \"|%,d|\""));
     }
 
     @Test
-    void numberFormatWithNegative(){
+    void numberFormatWithNegative() {
         NumberFormat numberFormat = new NumberFormat();
         assertEquals("|(25)|", numberFormat.generateOutput("\"-25\", \"|%(d|\""));
     }
 
     @Test
-    void numberFormatThrowNumberFormat(){
+    void numberFormatThrowNumberFormat() {
         NumberFormat numberFormat = new NumberFormat();
         assertThrows(NumberFormatException.class, () -> numberFormat.generateOutput("\"25a\", \"|%d|\""));
     }
 
     @Test
-    void numberFormatThrowIllegalArgument(){
+    void numberFormatThrowIllegalArgument() {
         NumberFormat numberFormat = new NumberFormat();
         assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, |%d|"));
     }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
@@ -1,0 +1,52 @@
+package io.metadew.iesi.script.execution.instruction.data.number;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NumberFormatTest {
+
+    @Test
+    void numberFormat() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("|00000000000000000093|", numberFormat.generateOutput("\"93\", \"|%020d|\""));
+    }
+
+    @Test
+    void numberFormatWithWidth(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("|                  93|", numberFormat.generateOutput("\"93\", \"|%20d|\""));
+    }
+
+    @Test
+    void numberFormatWithLeftJustifyingWidth(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("|93                  |", numberFormat.generateOutput("\"93\", \"|%-20d|\""));
+    }
+
+    @Test
+    void numberFormatWithComma(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("|10,000,000|", numberFormat.generateOutput("\"10000000\", \"|%,d|\""));
+    }
+
+    @Test
+    void numberFormatWithNegative(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("|(25)|", numberFormat.generateOutput("\"-25\", \"|%(d|\""));
+    }
+
+    @Test
+    void numberFormatThrowNumberFormat(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertThrows(NumberFormatException.class, () -> numberFormat.generateOutput("\"25a\", \"|%d|\""));
+    }
+
+    @Test
+    void numberFormatThrowIllegalArgument(){
+        NumberFormat numberFormat = new NumberFormat();
+        assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, |%d|"));
+    }
+
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/number/NumberFormatTest.java
@@ -49,4 +49,16 @@ class NumberFormatTest {
         assertThrows(IllegalArgumentException.class, () -> numberFormat.generateOutput("25a, |%d|"));
     }
 
+    @Test
+    void numberFormatWithoutMod() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("00000000000000000093", numberFormat.generateOutput("\"93\", \"%020d\""));
+    }
+
+    @Test
+    void numberFormatWithoutDoubleQuotes() {
+        NumberFormat numberFormat = new NumberFormat();
+        assertEquals("00000000000000000093", numberFormat.generateOutput("93, \"%020d\""));
+    }
+
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I want a new instruction that allows me to reformat numbers based on a give target format.
* name: number.format
* parameters:
  * number: text, the number that needs to be reformatted
  * format: text, the format in Java String#format syntax (https://dzone.com/articles/java-string-format-examples section Formatting an Integer)
* return: the textual representation of the number reformatted with the given format