### PR TITLE
fetch all environments unpaginated

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/EnvironmentsController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/EnvironmentsController.java
@@ -68,7 +68,8 @@ public class EnvironmentsController {
     @GetMapping("/list")
     @PreAuthorize("hasPrivilege('ENVIRONMENTS_READ')")
     public HalMultipleEmbeddedResource<EnvironmentDto> getAll() {
-        List<EnvironmentDto> environmentDtos = environmentDtoService.getAll();
+        Page<EnvironmentDto> environmentDtoPage = environmentDtoService.getAll(Pageable.unpaged());
+        List<EnvironmentDto> environmentDtos = environmentDtoPage.getContent();
         HalMultipleEmbeddedResource<EnvironmentDto> halMultipleEmbeddedResource = new HalMultipleEmbeddedResource<>();
         for (EnvironmentDto environmentDto : environmentDtos) {
             halMultipleEmbeddedResource.embedResource(environmentDto);

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/EnvironmentsController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/EnvironmentsController.java
@@ -55,7 +55,6 @@ public class EnvironmentsController {
         this.environmentDtoPagedResourcesAssembler = environmentDtoPagedResourcesAssembler;
     }
 
-
     @GetMapping("")
     @PreAuthorize("hasPrivilege('ENVIRONMENTS_READ')")
     public PagedModel<EnvironmentDto> getAll(Pageable pageable) {
@@ -64,6 +63,16 @@ public class EnvironmentsController {
         if (environmentDtoPage.hasContent())
             return environmentDtoPagedResourcesAssembler.toModel(environmentDtoPage, environmentDtoResourceAssembler::toModel);
         return (PagedModel<EnvironmentDto>) environmentDtoPagedResourcesAssembler.toEmptyModel(environmentDtoPage, EnvironmentDto.class);
+    }
+
+    @GetMapping("/list")
+    @PreAuthorize("hasPrivilege('ENVIRONMENTS_READ')")
+    public HalMultipleEmbeddedResource<EnvironmentDto> getAll() {
+        List<Environment> environments = environmentService.getAll();
+        return new HalMultipleEmbeddedResource<>(
+                environments.stream().filter(distinctByKey(Environment::getName))
+                        .map(environment -> environmentDtoResourceAssembler.toModel(environment))
+                        .collect(Collectors.toList()));
     }
 
     @GetMapping("/{name}")

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
@@ -65,6 +65,23 @@ public class EnvironmentDtoRepository extends PaginatedRepository implements IEn
         }
     }
 
+    @Override
+    public List<EnvironmentDto> getAll() {
+        try {
+            Map<String, EnvironmentDtoBuilder> environmentDtoBuilders = new LinkedHashMap<>();
+            String query = getFetchAllQuery(Pageable.unpaged());
+            CachedRowSet cachedRowSet = metadataRepositoryConfiguration.getConnectivityMetadataRepository().executeQuery(query, "reader");
+            while (cachedRowSet.next()){
+                mapRow(cachedRowSet, environmentDtoBuilders);
+            }
+            return environmentDtoBuilders.values().stream()
+                    .map(EnvironmentDtoBuilder::build)
+                    .collect(Collectors.toList());
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
     private long getRowSize() throws SQLException {
         String query = "select count(*) as row_count from (select distinct environments.ENV_NM " +
                 "from " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel(ENVIRONMENT_TABLE_LABEL).getName() + " environments " + ");";

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
@@ -65,23 +65,6 @@ public class EnvironmentDtoRepository extends PaginatedRepository implements IEn
         }
     }
 
-    @Override
-    public List<EnvironmentDto> getAll() {
-        try {
-            Map<String, EnvironmentDtoBuilder> environmentDtoBuilders = new LinkedHashMap<>();
-            String query = getFetchAllQuery(Pageable.unpaged());
-            CachedRowSet cachedRowSet = metadataRepositoryConfiguration.getConnectivityMetadataRepository().executeQuery(query, "reader");
-            while (cachedRowSet.next()){
-                mapRow(cachedRowSet, environmentDtoBuilders);
-            }
-            return environmentDtoBuilders.values().stream()
-                    .map(EnvironmentDtoBuilder::build)
-                    .collect(Collectors.toList());
-        }catch (SQLException e){
-            throw new RuntimeException(e);
-        }
-    }
-
     private long getRowSize() throws SQLException {
         String query = "select count(*) as row_count from (select distinct environments.ENV_NM " +
                 "from " + MetadataTablesConfiguration.getInstance().getMetadataTableNameByLabel(ENVIRONMENT_TABLE_LABEL).getName() + " environments " + ");";

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoService.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class EnvironmentDtoService implements IEnvironmentDtoService{
 
@@ -18,5 +20,10 @@ public class EnvironmentDtoService implements IEnvironmentDtoService{
     @Override
     public Page<EnvironmentDto> getAll(Pageable pageable) {
         return environmentDtoRepository.getAll(pageable);
+    }
+
+    @Override
+    public List<EnvironmentDto> getAll() {
+        return environmentDtoRepository.getAll();
     }
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoService.java
@@ -22,8 +22,4 @@ public class EnvironmentDtoService implements IEnvironmentDtoService{
         return environmentDtoRepository.getAll(pageable);
     }
 
-    @Override
-    public List<EnvironmentDto> getAll() {
-        return environmentDtoRepository.getAll();
-    }
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoRepository.java
@@ -3,7 +3,11 @@ package io.metadew.iesi.server.rest.environment.dto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface IEnvironmentDtoRepository {
 
     Page<EnvironmentDto> getAll(Pageable pageable);
+
+    List<EnvironmentDto> getAll();
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoRepository.java
@@ -8,6 +8,4 @@ import java.util.List;
 public interface IEnvironmentDtoRepository {
 
     Page<EnvironmentDto> getAll(Pageable pageable);
-
-    List<EnvironmentDto> getAll();
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoService.java
@@ -7,7 +7,4 @@ import java.util.List;
 
 public interface IEnvironmentDtoService {
     Page<EnvironmentDto> getAll(Pageable pageable);
-
-    List<EnvironmentDto> getAll();
-
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/IEnvironmentDtoService.java
@@ -3,6 +3,11 @@ package io.metadew.iesi.server.rest.environment.dto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface IEnvironmentDtoService {
     Page<EnvironmentDto> getAll(Pageable pageable);
+
+    List<EnvironmentDto> getAll();
+
 }

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/configuration/security/jwt/EnvironmentsControllerSecurityTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/configuration/security/jwt/EnvironmentsControllerSecurityTest.java
@@ -65,7 +65,7 @@ class EnvironmentsControllerSecurityTest {
 
     @Test
     void testGetAllNoUser() throws Exception {
-        assertThatThrownBy(() -> environmentsController.getAll(Pageable.unpaged()))
+        assertThatThrownBy(() -> environmentsController.getAll())
                 .isInstanceOf(AuthenticationCredentialsNotFoundException.class);
     }
 
@@ -105,8 +105,7 @@ class EnvironmentsControllerSecurityTest {
     @WithIesiUser(username = "spring",
             authorities = {"ENVIRONMENTS_READ@PUBLIC"})
     void testGetEnvironmentReadPrivilege() throws Exception {
-        Pageable pageable = Pageable.unpaged();
-        environmentsController.getAll(pageable);
+        environmentsController.getAll();
     }
 
     @Test

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
@@ -184,19 +184,4 @@ class EnvironmentDtoRepositoryTest {
         return new EnvironmentParameter(environmentName, environmentParameterName, value);
     }
 
-    @Test
-    void getAllListTest() {
-        Environment environment1 = createEnvironment("iesi-test");
-        Environment environment2 = createEnvironment("iesi-dev");
-        environmentConfiguration.insert(environment1);
-        environmentConfiguration.insert(environment2);
-        EnvironmentDto environmentDto1 = environmentDtoResourceAssembler.toModel(environment1);
-        EnvironmentDto environmentDto2 = environmentDtoResourceAssembler.toModel(environment2);
-        assertThat(environmentDtoRepository.getAll()).containsOnly(
-                environmentDto1,
-                environmentDto2
-        );
-    }
-
-
 }

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
@@ -184,5 +184,19 @@ class EnvironmentDtoRepositoryTest {
         return new EnvironmentParameter(environmentName, environmentParameterName, value);
     }
 
+    @Test
+    void getAllListTest() {
+        Environment environment1 = createEnvironment("iesi-test");
+        Environment environment2 = createEnvironment("iesi-dev");
+        environmentConfiguration.insert(environment1);
+        environmentConfiguration.insert(environment2);
+        EnvironmentDto environmentDto1 = environmentDtoResourceAssembler.toModel(environment1);
+        EnvironmentDto environmentDto2 = environmentDtoResourceAssembler.toModel(environment2);
+        assertThat(environmentDtoRepository.getAll()).containsOnly(
+                environmentDto1,
+                environmentDto2
+        );
+    }
+
 
 }


### PR DESCRIPTION
**Description**
create a new GET /environment/list endpoint allowing to the environments to be fetched in a non paginated way. This is needed to allow the UI to fetch ALL of the environments when the user wants to execute a script.

extend api doc from metadew/iesi-api-documentation#22
extend code from #352 