### PR TITLE
Script Design - Action Edits - Changes not stored

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/ScriptConfiguration.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/metadata/configuration/script/ScriptConfiguration.java
@@ -18,8 +18,6 @@ import io.metadew.iesi.metadata.definition.security.SecurityGroupKey;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
 import io.metadew.iesi.metadata.tools.IdentifierTools;
 import lombok.extern.log4j.Log4j2;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import javax.sql.rowset.CachedRowSet;
 import java.io.PrintWriter;
@@ -378,6 +376,22 @@ public class ScriptConfiguration extends Configuration<Script, ScriptKey> {
     @Override
     public void update(Script script) {
         ScriptVersionConfiguration.getInstance().update(script.getVersion());
+        ScriptKey scriptKey = script.getMetadataKey();
+
+        ScriptParameterConfiguration.getInstance().deleteByScript(scriptKey);
+        for (ScriptParameter scriptParameter : script.getParameters()) {
+            ScriptParameterConfiguration.getInstance().insert(scriptParameter);
+        }
+
+        ActionConfiguration.getInstance().deleteByScript(scriptKey);
+        for (Action action : script.getActions()) {
+            ActionConfiguration.getInstance().insert(action);
+        }
+
+        ScriptLabelConfiguration.getInstance().deleteByScript(scriptKey);
+        for (ScriptLabel scriptLabel : script.getLabels()) {
+            ScriptLabelConfiguration.getInstance().insert(scriptLabel);
+        }
         getMetadataRepository().executeUpdate(getInsertStatement(script));
     }
 


### PR DESCRIPTION
Screen: Script Design (detail)
Functionality: Perform edit on existing action (action parameters - description)

Description: Performed changes/edits on an existing action are not stored when saving the modifications. Original input remains.

Steps to reproduce:

Open script design & modify existing action (e.g. change the action description)
Save the modification in current script version (Save > Update current version)
Leave the script design screen (e.g. go back to script overview)
Lookup the modified script/actions
Actual:
= original description still visible - edit(s) were not stored

Expected:
= modified/updated description is visible - edit(s) were correctly stored