### PR TITLE
Allow versionning of components

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/HttpComponentService.java
@@ -70,9 +70,9 @@ public class HttpComponentService implements IHttpComponentService {
     }
 
     @Override
-    public HttpComponent getAndTrace(String httpComponentReferenceName, ActionExecution actionExecution, String actionParameterName) {
-        Component component = ComponentConfiguration.getInstance().getByNameAndVersion(httpComponentReferenceName, 1L)
-                .orElseThrow(() -> new RuntimeException("Could not find http component with name " + httpComponentReferenceName + "and version 1"));
+    public HttpComponent getAndTrace(String httpComponentReferenceName, ActionExecution actionExecution, String actionParameterName, Long version) {
+        Component component = ComponentConfiguration.getInstance().getByNameAndVersion(httpComponentReferenceName, version)
+                .orElseThrow(() -> new RuntimeException("Could not find http component with name " + httpComponentReferenceName + " and version " + version));
         HttpComponentDefinition httpComponentDefinition = HttpComponentDefinitionService.getInstance().convertAndTrace(component, actionExecution, actionParameterName);
         return convertAndTrace(httpComponentDefinition, actionExecution, actionParameterName);
     }
@@ -109,7 +109,7 @@ public class HttpComponentService implements IHttpComponentService {
         return httpComponent;
     }
 
-    private String resolveEndpoint(String endpoint, ActionExecution actionExecution) {
+    protected String resolveEndpoint(String endpoint, ActionExecution actionExecution) {
         String actionResolvedValue = actionExecution.getActionControl().getActionRuntime().resolveRuntimeVariables(endpoint);
         String resolvedInputValue = actionExecution.getExecutionControl().getExecutionRuntime().resolveVariables(actionExecution, actionResolvedValue);
         resolvedInputValue = actionExecution.getExecutionControl().getExecutionRuntime().resolveConceptLookup(resolvedInputValue).getValue();
@@ -118,7 +118,7 @@ public class HttpComponentService implements IHttpComponentService {
         return convertEndpointDatatype(DataTypeHandler.getInstance().resolve(decryptedInputValue, actionExecution.getExecutionControl().getExecutionRuntime()));
     }
 
-    private String resolveType(String type, ActionExecution actionExecution) {
+    protected String resolveType(String type, ActionExecution actionExecution) {
         String actionResolvedValue = actionExecution.getActionControl().getActionRuntime().resolveRuntimeVariables(type);
         String resolvedInputValue = actionExecution.getExecutionControl().getExecutionRuntime().resolveVariables(actionExecution, actionResolvedValue);
         resolvedInputValue = actionExecution.getExecutionControl().getExecutionRuntime().resolveConceptLookup(resolvedInputValue).getValue();

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/IHttpComponentService.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/component/http/IHttpComponentService.java
@@ -14,7 +14,7 @@ public interface IHttpComponentService {
 
     public HttpComponent get(String httpComponentReferenceName, ActionExecution actionExecution);
 
-    public HttpComponent getAndTrace(String httpComponentReferenceName, ActionExecution actionExecution, String actionParameterName);
+    public HttpComponent getAndTrace(String httpComponentReferenceName, ActionExecution actionExecution, String actionParameterName, Long version);
 
     public String getUri(HttpComponent httpComponent);
 

--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -43,6 +43,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
 
     private static final String ACTION_TYPE = "http.executeRequest";
     private static final String REQUEST_KEY = "request";
+    private static final String REQUEST_VERSION = "requestVersion";
     private static final String BODY_KEY = "body";
     private static final String PROXY_KEY = "proxy";
     private static final String SET_DATASET_KEY = "setDataset";
@@ -68,9 +69,9 @@ public class HttpExecuteRequest extends ActionTypeExecution {
         super(executionControl, scriptExecution, actionExecution);
     }
 
-    public void prepareAction() throws URISyntaxException, HttpRequestBuilderException, KeyValuePairException {
+    public void prepareAction() throws HttpRequestBuilderException, URISyntaxException {
 
-        HttpComponent httpComponent = HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(getParameterResolvedValue(REQUEST_KEY)), getActionExecution(), REQUEST_KEY);
+        HttpComponent httpComponent = HttpComponentService.getInstance().getAndTrace(convertHttpRequestName(getParameterResolvedValue(REQUEST_KEY)), getActionExecution(), REQUEST_KEY, convertHttpRequestVersion(getParameterResolvedValue(REQUEST_VERSION)));
 
         Optional<String> body = convertHttpRequestBody(getParameterResolvedValue(BODY_KEY));
 
@@ -310,6 +311,19 @@ public class HttpExecuteRequest extends ActionTypeExecution {
                     httpRequestName.getClass()));
             return httpRequestName.toString();
         }
+    }
+
+    private Long convertHttpRequestVersion(DataType httpRequestVersion) {
+        if (httpRequestVersion == null) {
+            return null;
+        }
+        if (httpRequestVersion instanceof Text) {
+            return Long.parseLong(httpRequestVersion.toString());
+        }
+        log.warn(MessageFormat.format(getActionExecution().getAction().getType() + " does not accept {0} as type for request name",
+                httpRequestVersion.getClass()));
+        return null;
+
     }
 
     private void checkStatusCode(HttpResponse httpResponse) {

--- a/core/java/iesi-core/src/main/resources/application-action-types.yml
+++ b/core/java/iesi-core/src/main/resources/application-action-types.yml
@@ -772,6 +772,13 @@ iesi:
             encrypted: false
             subroutine:
             impersonate: false
+          requestVersion:
+            description: Version of the http component
+            type: string
+            mandatory: false
+            encrypted: false
+            subroutine:
+            impersonate: false
           setRuntimeVariables:
             description: Flag indicating if an expected result will be set as a runtime variable
             type: string

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/component/http/HttpComponentServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/component/http/HttpComponentServiceTest.java
@@ -7,6 +7,16 @@ import io.metadew.iesi.connection.http.HttpConnectionService;
 import io.metadew.iesi.connection.http.request.HttpGetRequest;
 import io.metadew.iesi.connection.http.request.HttpPostRequest;
 import io.metadew.iesi.connection.http.request.HttpRequestBuilderException;
+import io.metadew.iesi.metadata.configuration.component.ComponentConfiguration;
+import io.metadew.iesi.metadata.configuration.connection.ConnectionConfiguration;
+import io.metadew.iesi.metadata.definition.component.Component;
+import io.metadew.iesi.metadata.definition.component.ComponentParameter;
+import io.metadew.iesi.metadata.definition.component.ComponentVersion;
+import io.metadew.iesi.metadata.definition.component.key.ComponentKey;
+import io.metadew.iesi.metadata.definition.component.key.ComponentParameterKey;
+import io.metadew.iesi.metadata.definition.component.key.ComponentVersionKey;
+import io.metadew.iesi.metadata.definition.connection.Connection;
+import io.metadew.iesi.metadata.definition.connection.ConnectionParameter;
 import io.metadew.iesi.metadata.repository.MetadataRepository;
 import io.metadew.iesi.script.execution.*;
 import org.apache.http.client.methods.HttpGet;
@@ -18,10 +28,12 @@ import org.powermock.reflect.Whitebox;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class HttpComponentServiceTest {
@@ -171,6 +183,243 @@ class HttpComponentServiceTest {
         Whitebox.setInternalState(HttpConnectionService.class, "INSTANCE", (HttpConnectionService) null);
         Whitebox.setInternalState(HttpHeaderService.class, "INSTANCE", (HttpHeaderService) null);
         Whitebox.setInternalState(HttpQueryParameterService.class, "INSTANCE", (HttpQueryParameterService) null);
+    }
+
+    @Test
+    void getAndTraceTestRightNameAndVersion() {
+        HttpComponentService httpComponentService = HttpComponentService.getInstance();
+        HttpComponentService httpComponentServiceSpy = Mockito.spy(httpComponentService);
+        ActionExecution actionExecution = mock(ActionExecution.class);
+        ExecutionControl executionControl = mock(ExecutionControl.class);
+        Long componentVersion1 = 0L;
+        Long componentVersion2 = 1L;
+
+        when(actionExecution.getExecutionControl()).thenReturn(executionControl);
+        when(executionControl.getProcessId()).thenReturn(1L);
+        when(executionControl.getRunId()).thenReturn("1");
+        when(executionControl.getEnvName()).thenReturn("env0");
+
+        Mockito.doReturn("/pet").when(httpComponentServiceSpy).resolveEndpoint(anyString(), any(ActionExecution.class));
+        Mockito.doReturn("PUT").when(httpComponentServiceSpy).resolveType(anyString(), any(ActionExecution.class));
+
+        HttpComponent httpComponent1 = new HttpComponent(
+                "component1",
+                componentVersion1,
+                "description",
+                new HttpConnection(
+                        "connectionName",
+                        "description",
+                        "env0",
+                        "http://test.com",
+                        "/api",
+                        8080,
+                        false
+                ),
+                "/pet",
+                "GET",
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+        ConnectionConfiguration.getInstance().insert(new Connection(
+                "connectionName",
+                "http",
+                "description",
+                "env0",
+                Stream.of(
+                        new ConnectionParameter("connectionName", "env0", "host", "http://test.com"),
+                        new ConnectionParameter("connectionName", "env0", "port", "8080"),
+                        new ConnectionParameter("connectionName", "env0", "baseUrl", "/api"),
+                        new ConnectionParameter("connectionName", "env0", "tls", "N")
+                ).collect(Collectors.toList())
+
+        ));
+        ComponentConfiguration.getInstance().insert(new Component(
+                    new ComponentKey("component1", componentVersion1),
+                    "http.request",
+                    "component1",
+                "description",
+                    new ComponentVersion( new ComponentVersionKey("component1", componentVersion1), "description"),
+                    Stream.of(
+                            ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("/pet").build(),
+                            ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("GET").build(),
+                            ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("connectionName").build()
+                    ).collect(Collectors.toList()),
+                  new ArrayList<>()
+                ));
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion2),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion2), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("PUT").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+
+        assertThat(httpComponentServiceSpy.getAndTrace("component1", actionExecution, "request", 0L)).isEqualTo(httpComponent1);
+    }
+
+    @Test
+    void getAndTraceTestNameAndUnknownVersion() {
+        HttpComponentService httpComponentService = HttpComponentService.getInstance();
+        HttpComponentService httpComponentServiceSpy = Mockito.spy(httpComponentService);
+        ActionExecution actionExecution = mock(ActionExecution.class);
+        ExecutionControl executionControl = mock(ExecutionControl.class);
+        Long componentVersion1 = 0L;
+        Long componentVersion2 = 1L;
+
+        when (actionExecution.getExecutionControl()).thenReturn(executionControl);
+        when(executionControl.getProcessId()).thenReturn(1L);
+        when(executionControl.getRunId()).thenReturn("1");
+        when(executionControl.getEnvName()).thenReturn("env0");
+
+        Mockito.doReturn("/pet").when(httpComponentServiceSpy).resolveEndpoint(anyString(), any(ActionExecution.class));
+        Mockito.doReturn("GET").when(httpComponentServiceSpy).resolveType(anyString(), any(ActionExecution.class));
+
+        ConnectionConfiguration.getInstance().insert(new Connection(
+                "connectionName",
+                "http",
+                "description",
+                "env0",
+                Stream.of(
+                        new ConnectionParameter("connectionName", "env0", "host", "http://test.com"),
+                        new ConnectionParameter("connectionName", "env0", "port", "8080"),
+                        new ConnectionParameter("connectionName", "env0", "baseUrl", "/api"),
+                        new ConnectionParameter("connectionName", "env0", "tls", "N")
+                ).collect(Collectors.toList())
+
+        ));
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion1),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion1), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("GET").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion2),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion2), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("PUT").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+
+        assertThatThrownBy(() -> {
+            httpComponentServiceSpy.getAndTrace("component1", actionExecution, "request", 3L);
+        }).isInstanceOf(RuntimeException.class).hasMessage("Could not find http component with name component1 and version 3");
+    }
+
+    @Test
+    void getAndTraceTestNameAndNoVersion() {
+        HttpComponentService httpComponentService = HttpComponentService.getInstance();
+        HttpComponentService httpComponentServiceSpy = Mockito.spy(httpComponentService);
+        ActionExecution actionExecution = mock(ActionExecution.class);
+        ExecutionControl executionControl = mock(ExecutionControl.class);
+        Long componentVersion1 = 0L;
+        Long componentVersion2 = 2L;
+        Long componentVersion3 = 3L;
+
+        HttpComponent httpComponent3 = new HttpComponent(
+                "component1",
+                componentVersion3,
+                "description",
+                new HttpConnection(
+                        "connectionName",
+                        "description",
+                        "env0",
+                        "http://test.com",
+                        "/api",
+                        8080,
+                        false
+                ),
+                "/pet",
+                "POST",
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+
+        when (actionExecution.getExecutionControl()).thenReturn(executionControl);
+        when(executionControl.getProcessId()).thenReturn(1L);
+        when(executionControl.getRunId()).thenReturn("1");
+        when(executionControl.getEnvName()).thenReturn("env0");
+
+        Mockito.doReturn("/pet").when(httpComponentServiceSpy).resolveEndpoint(anyString(), any(ActionExecution.class));
+        Mockito.doReturn("POST").when(httpComponentServiceSpy).resolveType(anyString(), any(ActionExecution.class));
+
+        ConnectionConfiguration.getInstance().insert(new Connection(
+                "connectionName",
+                "http",
+                "description",
+                "env0",
+                Stream.of(
+                        new ConnectionParameter("connectionName", "env0", "host", "http://test.com"),
+                        new ConnectionParameter("connectionName", "env0", "port", "8080"),
+                        new ConnectionParameter("connectionName", "env0", "baseUrl", "/api"),
+                        new ConnectionParameter("connectionName", "env0", "tls", "N")
+                ).collect(Collectors.toList())
+
+        ));
+
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion1),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion1), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("GET").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion1)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion2),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion2), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("PUT").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion2)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+
+        ComponentConfiguration.getInstance().insert(new Component(
+                new ComponentKey("component1", componentVersion3),
+                "http.request",
+                "component1",
+                "description",
+                new ComponentVersion( new ComponentVersionKey("component1", componentVersion3), "description"),
+                Stream.of(
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("endpoint").componentKey(new ComponentKey("component1", componentVersion3)).build()).value("/pet").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("type").componentKey(new ComponentKey("component1", componentVersion3)).build()).value("PUT").build(),
+                        ComponentParameter.builder().componentParameterKey(ComponentParameterKey.builder().parameterName("connection").componentKey(new ComponentKey("component1", componentVersion3)).build()).value("connectionName").build()
+                ).collect(Collectors.toList()),
+                new ArrayList<>()
+        ));
+
+        assertThat(httpComponentServiceSpy.getAndTrace("component1", actionExecution, "request", null)).isEqualTo(httpComponent3);
     }
 
     @Disabled

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/component/http/HttpComponentServiceTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/component/http/HttpComponentServiceTest.java
@@ -191,8 +191,8 @@ class HttpComponentServiceTest {
         HttpComponentService httpComponentServiceSpy = Mockito.spy(httpComponentService);
         ActionExecution actionExecution = mock(ActionExecution.class);
         ExecutionControl executionControl = mock(ExecutionControl.class);
-        Long componentVersion1 = 0L;
-        Long componentVersion2 = 1L;
+        long componentVersion1 = 0L;
+        long componentVersion2 = 1L;
 
         when(actionExecution.getExecutionControl()).thenReturn(executionControl);
         when(executionControl.getProcessId()).thenReturn(1L);
@@ -200,7 +200,7 @@ class HttpComponentServiceTest {
         when(executionControl.getEnvName()).thenReturn("env0");
 
         Mockito.doReturn("/pet").when(httpComponentServiceSpy).resolveEndpoint(anyString(), any(ActionExecution.class));
-        Mockito.doReturn("PUT").when(httpComponentServiceSpy).resolveType(anyString(), any(ActionExecution.class));
+        Mockito.doReturn("GET").when(httpComponentServiceSpy).resolveType(anyString(), any(ActionExecution.class));
 
         HttpComponent httpComponent1 = new HttpComponent(
                 "component1",

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/configuration/component/ComponentVersionConfigurationTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/metadata/configuration/component/ComponentVersionConfigurationTest.java
@@ -262,9 +262,12 @@ class ComponentVersionConfigurationTest {
         ComponentVersionConfiguration.getInstance().insert(componentVersion2);
         ComponentVersionConfiguration.getInstance().insert(componentVersion3);
 
-        assertEquals(2,ComponentVersionConfiguration.getInstance().getLatestVersionByComponentId(componentVersion1.getMetadataKey().getComponentKey().getId()));
-        assertEquals(1,ComponentVersionConfiguration.getInstance().getLatestVersionByComponentId(componentVersion3.getMetadataKey().getComponentKey().getId()));
-
+        Optional<ComponentVersion> fetchedComponentVersion2 = ComponentVersionConfiguration.getInstance().getLatestVersionByComponentId(componentVersion1.getMetadataKey().getComponentKey().getId());
+        Optional<ComponentVersion> fetchedComponentVersion3 = ComponentVersionConfiguration.getInstance().getLatestVersionByComponentId(componentVersion3.getMetadataKey().getComponentKey().getId());
+        assertTrue(fetchedComponentVersion2.isPresent());
+        assertEquals(2, fetchedComponentVersion2.get().getMetadataKey().getComponentKey().getVersionNumber());
+        assertTrue(fetchedComponentVersion3.isPresent());
+        assertEquals(1, fetchedComponentVersion3.get().getMetadataKey().getComponentKey().getVersionNumber());
     }
 
 }

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/action/http/HttpExecuteRequestTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/action/http/HttpExecuteRequestTest.java
@@ -417,7 +417,7 @@ class HttpExecuteRequestTest {
     void mockGetAndTraceHttpComponent(HttpComponent httpComponent) {
         doReturn(httpComponent)
                 .when(httpComponentServiceSpy)
-                .getAndTrace("request", actionExecution, "request", httpComponent.getVersion());
+                .getAndTrace("request", actionExecution, "request", null);
     }
 
     HttpComponent createBaseComponent(List<HttpHeader> headers, List<HttpQueryParameter> queryParameters) {

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/action/http/HttpExecuteRequestTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/action/http/HttpExecuteRequestTest.java
@@ -76,7 +76,6 @@ class HttpExecuteRequestTest {
         Whitebox.setInternalState(HttpComponentService.class, "instance", (HttpComponentService) null);
     }
 
-
     @Test
     void prepareNoHeadersAndNoQueries() throws Exception {
 
@@ -418,7 +417,7 @@ class HttpExecuteRequestTest {
     void mockGetAndTraceHttpComponent(HttpComponent httpComponent) {
         doReturn(httpComponent)
                 .when(httpComponentServiceSpy)
-                .getAndTrace("request", actionExecution, "request");
+                .getAndTrace("request", actionExecution, "request", httpComponent.getVersion());
     }
 
     HttpComponent createBaseComponent(List<HttpHeader> headers, List<HttpQueryParameter> queryParameters) {

--- a/core/java/iesi-rest-without-microservices/pom.xml
+++ b/core/java/iesi-rest-without-microservices/pom.xml
@@ -174,6 +174,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.16</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-action-types.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-action-types.yml
@@ -772,6 +772,13 @@ iesi:
             encrypted: false
             subroutine:
             impersonate: false
+          requestVersion:
+            description: Version of the http component
+            type: string
+            mandatory: false
+            encrypted: false
+            subroutine:
+            impersonate: false
           setRuntimeVariables:
             description: Flag indicating if an expected result will be set as a runtime variable
             type: string

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
@@ -10,7 +10,7 @@ iesi:
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
          type: sqlite
-         file: /home/hkhattabi/metadew/iesi/core/java/iesi-core/repository.db3
+         file: repository.db3
 
 #          type: h2
 #          mode: embedded

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi-repository.yml
@@ -10,7 +10,7 @@ iesi:
         # type of database: sqlite, h2, mssql, netezza, oracle, postgresql
         coordinator:
          type: sqlite
-         file: ./repository.db3
+         file: /home/hkhattabi/metadew/iesi/core/java/iesi-core/repository.db3
 
 #          type: h2
 #          mode: embedded

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi.yml
@@ -9,7 +9,7 @@ iesi:
     mode: standalone
     threads:
       timeout: 30
-  home: '.'
+  home: '/home/hkhattabi/metadew/iesi/core/java/iesi-core'
   security:
     enabled: true
     jwt:

--- a/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi.yml
+++ b/core/java/iesi-rest-without-microservices/src/main/resources/application-iesi.yml
@@ -9,7 +9,7 @@ iesi:
     mode: standalone
     threads:
       timeout: 30
-  home: '/home/hkhattabi/metadew/iesi/core/java/iesi-core'
+  home: '.'
   security:
     enabled: true
     jwt:


### PR DESCRIPTION
When choosing a component from an action-type, the user can be able to target a specific version of that component by writing the version number in the input parameter field. 

If nothing is provided, the application will choose the latest version by default, and, if the version provided doesn't exist, display an error message

-- **Requirements**
Goal: As an end-user - I want to be able to create multiple versions of one component and refer to a specific component version during script design for action type: http.executeRequest	

AS IS:		
	Action Type: http.executeRequest	
		- Refer to component by completing the action parameter: "request"
		- No component/request version can be specified - default version is last version
		
TO BE:	
        Action Type: http.executeRequest	
		- Refer to component by completing the action parameter: "request"
		- component/request version can be specified
		- if no version is provided, then default version is last version
		
Dev specifications:		
	Must:	- New action parameter for actiontype: http.executeRequest - "request version"
	Must:	- optional field
	Must:	 - when empty: default version is last version (example: fwk.executeScript)
	Must:	- when version is specified, but not existing - returncode: component cannot be found
	
UI specifications:		
	Screen:	Create Script - Add Action - Action Type http.executeRequest - Action Parameters details
	Must:	- New action parameter for actiontype: http.executeRequest - "request version"
	Must:	- New action parameter for actiontype: http.executeRequest - "request version" - description: "version of the request to run"
	Must:	- optional field - below box "Request"