### PR TITLE
Add encryption api endpoint to encrypt values

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
@@ -1,0 +1,35 @@
+package io.metadew.iesi.server.rest.encrypter;
+
+import io.metadew.iesi.server.rest.encrypter.dto.EncryptDto;
+import io.metadew.iesi.server.rest.encrypter.dto.EncryptPostDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * The encryption controller is used to provide encrypted text.
+ * @author Suyash.d.jain
+ */
+
+@RestController
+@Tag(name = "encrypt", description = "controller to encrypt text")
+@RequestMapping("/encrypt")
+@ConditionalOnWebApplication
+public class EncryptionController {
+
+    private final IEncryptionService encryptionService;
+
+    public EncryptionController(IEncryptionService encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
+    @PostMapping("")
+    public EncryptDto getEncryptedPassword(@Valid @RequestBody EncryptPostDto encryptPostDto){
+        return new EncryptDto(encryptionService.getEncryptedPassword(encryptPostDto.getText()));
+    }
+}

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
@@ -18,7 +18,7 @@ import javax.validation.Valid;
 
 @RestController
 @Tag(name = "encrypt", description = "controller to encrypt text")
-@RequestMapping("/encrypt")
+@RequestMapping("/encryption")
 @ConditionalOnWebApplication
 public class EncryptionController {
 
@@ -28,7 +28,7 @@ public class EncryptionController {
         this.encryptionService = encryptionService;
     }
 
-    @PostMapping("")
+    @PostMapping("/encrypt")
     public EncryptDto getEncryptedPassword(@Valid @RequestBody EncryptPostDto encryptPostDto){
         return new EncryptDto(encryptionService.getEncryptedPassword(encryptPostDto.getText()));
     }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionController.java
@@ -29,7 +29,7 @@ public class EncryptionController {
     }
 
     @PostMapping("/encrypt")
-    public EncryptDto getEncryptedPassword(@Valid @RequestBody EncryptPostDto encryptPostDto){
-        return new EncryptDto(encryptionService.getEncryptedPassword(encryptPostDto.getText()));
+    public EncryptDto getEncryptedText(@Valid @RequestBody EncryptPostDto encryptPostDto){
+        return new EncryptDto(encryptionService.getEncryptedText(encryptPostDto.getText()));
     }
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionService.java
@@ -1,0 +1,27 @@
+package io.metadew.iesi.server.rest.encrypter;
+
+import io.metadew.iesi.common.crypto.FrameworkCrypto;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.stereotype.Service;
+
+/**
+ * The encryption service is used to encrypt text through FrameworkCrypto.
+ * @author Suyash.d.jain
+ */
+
+@Service
+@ConditionalOnWebApplication
+public class EncryptionService implements IEncryptionService{
+
+    private FrameworkCrypto frameworkCrypto;
+
+    private EncryptionService(FrameworkCrypto frameworkCrypto) {
+        this.frameworkCrypto = frameworkCrypto;
+    }
+
+    @Override
+    public String getEncryptedPassword(String text) {
+        return frameworkCrypto.encrypt(text);
+    }
+
+}

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/EncryptionService.java
@@ -20,7 +20,7 @@ public class EncryptionService implements IEncryptionService{
     }
 
     @Override
-    public String getEncryptedPassword(String text) {
+    public String getEncryptedText(String text) {
         return frameworkCrypto.encrypt(text);
     }
 

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/IEncryptionService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/IEncryptionService.java
@@ -1,0 +1,6 @@
+package io.metadew.iesi.server.rest.encrypter;
+
+public interface IEncryptionService {
+
+    String getEncryptedPassword(String password);
+}

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/IEncryptionService.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/IEncryptionService.java
@@ -2,5 +2,5 @@ package io.metadew.iesi.server.rest.encrypter;
 
 public interface IEncryptionService {
 
-    String getEncryptedPassword(String password);
+    String getEncryptedText(String password);
 }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/dto/EncryptDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/dto/EncryptDto.java
@@ -1,0 +1,14 @@
+package io.metadew.iesi.server.rest.encrypter.dto;
+
+import lombok.*;
+import org.springframework.hateoas.RepresentationModel;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EncryptDto extends RepresentationModel<EncryptDto> {
+
+    private String encryptedText;
+}

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/dto/EncryptPostDto.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/encrypter/dto/EncryptPostDto.java
@@ -1,0 +1,14 @@
+package io.metadew.iesi.server.rest.encrypter.dto;
+
+import lombok.*;
+import org.springframework.hateoas.RepresentationModel;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EncryptPostDto extends RepresentationModel<EncryptPostDto> {
+
+    private String text;
+}

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/encrypter/EncryptionControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/encrypter/EncryptionControllerTest.java
@@ -1,0 +1,35 @@
+package io.metadew.iesi.server.rest.encrypter;
+
+import io.metadew.iesi.server.rest.Application;
+import io.metadew.iesi.server.rest.configuration.TestConfiguration;
+import io.metadew.iesi.server.rest.configuration.security.MethodSecurityConfiguration;
+import io.metadew.iesi.server.rest.encrypter.dto.EncryptPostDto;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Log4j2
+@SpringBootTest(classes = {Application.class, MethodSecurityConfiguration.class, TestConfiguration.class},
+        properties = {"spring.main.allow-bean-definition-overriding=true", "iesi.security.enabled=true"})
+@ExtendWith({MockitoExtension.class, SpringExtension.class})
+@ActiveProfiles({"http", "test"})
+@DirtiesContext
+class EncryptionControllerTest {
+
+    @MockBean
+    private EncryptionService encryptionService;
+
+    @MockBean
+    private EncryptionController controller;
+
+    @Test
+    void getEncryptedPassword() {
+        controller.getEncryptedPassword(new EncryptPostDto("password"));
+    }
+}

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/encrypter/EncryptionControllerTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/encrypter/EncryptionControllerTest.java
@@ -29,7 +29,7 @@ class EncryptionControllerTest {
     private EncryptionController controller;
 
     @Test
-    void getEncryptedPassword() {
-        controller.getEncryptedPassword(new EncryptPostDto("password"));
+    void getEncryptedText() {
+        controller.getEncryptedText(new EncryptPostDto("password"));
     }
 }


### PR DESCRIPTION
**ID**
187d769

Currently, we can encrypt data by providing the values to be encrypted through the terminal. 
It is better now to be able to execute this process from an API call through an endpoint.