### PR TITLE
Cannot provide empty request version

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/http/HttpExecuteRequest.java
@@ -320,7 +320,7 @@ public class HttpExecuteRequest extends ActionTypeExecution {
     }
 
     private Long convertHttpRequestVersion(DataType httpRequestVersion) {
-        if (httpRequestVersion == null) {
+        if (httpRequestVersion == null || httpRequestVersion instanceof Null) {
             return null;
         }
         if (httpRequestVersion instanceof Text) {


### PR DESCRIPTION
**ID**
7dfbfa6

**Steps to reproduce**
- Go to actiontype: http.executeRequest
- Enter value for field requestVersion + save action
- Delete value for field requestVersion + save action
- error: http.executeRequest does not accept class io.metadew.iesi.datatypes._null.Null as type for request name

**Conclusion**
when actionparameter ‘requestVersion’ for actiontype: http.executeRequest has been modified/tampered, it does not use the default latest version when value gets deleted/empty – when actionparameter ‘requestVersion’ has not been modified/tampered before (i.e. untouched/left empty), it does take the default latest version

