### PR TITLE
Actiontype - sql.executeQuery -'nullPointerException' for actionparam 'appendOutput'

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/action/sql/SqlExecuteQuery.java
@@ -59,7 +59,7 @@ public class SqlExecuteQuery extends ActionTypeExecution {
         }
     }
 
-    private boolean convertAppendOutput(DataType appendOutput) {
+    /*private boolean convertAppendOutput(DataType appendOutput) {
         if (appendOutput == null || appendOutput instanceof Null){
             return false;
         }
@@ -70,7 +70,7 @@ public class SqlExecuteQuery extends ActionTypeExecution {
                     appendOutput.getClass()));
             return false;
         }
-    }
+    }*/
 
     private String convertDatasetReferenceName(DataType datasetReferenceName) {
         if (datasetReferenceName == null || datasetReferenceName instanceof Null){
@@ -89,7 +89,11 @@ public class SqlExecuteQuery extends ActionTypeExecution {
         String query = convertQuery(getParameterResolvedValue(QUERY_KEY));
         String connectionName = convertConnectionName(getParameterResolvedValue(CONNECTION_KEY));
         String outputDatasetReferenceName = convertDatasetReferenceName(getParameterResolvedValue(OUTPUT_DATASET_KEY));
-        boolean appendOutput = convertAppendOutput(getParameterResolvedValue(APPEND_OUTPUT_KEY));
+        /*
+         appendOuput is not being used below so commenting out this block
+         because it is throwing NullPointerException while resolving value
+         boolean appendOutput = convertAppendOutput(getParameterResolvedValue(APPEND_OUTPUT_KEY));
+        */
         // Get Connection
         Connection connection = ConnectionConfiguration.getInstance()
                 .get(new ConnectionKey(connectionName, this.getExecutionControl().getEnvName()))


### PR DESCRIPTION
**Describe the bug**
When executing an action of actiontype: sql.executeQuery - a nullPointerException gets thrown when an empty value is provided for the optional actionparameter: 'appendOutput'.

**To Reproduce**
Steps to reproduce the behavior:
1. Create script
2. Select actiontype: sql.executeQuery
3. Provide values for parameters: outputDataset - connection - query
4. execute the script
5. = nullPointerException

AS IS:
- actionparameter 'appendOutput' is not a mandatory field
- IESI is performing a check on empty value and is throwing an nullPointer if no value is provided
- If values Y or N is provided in the paramfield 'appendOutput' - the action is succesfull - if no value is provided, the action is stopped

TO BE:
-  actionparameter 'appendOutput' is not a mandatory field
- IESI should not be performing a check on empty value since this is an optional field and users have a choice to provide a value or not

**Additional context**
Business Owner: Naïri
Additional error logging: 
2021-11-10 10:01:01,901 DEBUG [i.m.i.s.e.ActionControl] - action.output=action.exception:java.lang.NullPointerException
	at io.metadew.iesi.script.action.sql.SqlExecuteQuery.convertAppendOutput(SqlExecuteQuery.java:66)
	at io.metadew.iesi.script.action.sql.SqlExecuteQuery.executeAction(SqlExecuteQuery.java:85)
	at io.metadew.iesi.script.action.ActionTypeExecution.execute(ActionTypeExecution.java:60)
	at io.metadew.iesi.script.execution.ActionExecution.execute(ActionExecution.java:92)
	at io.metadew.iesi.script.execution.ScriptExecution.execute(ScriptExecution.java:83)
	at io.metadew.iesi.runtime.script.ScriptNameExecutor.execute(ScriptNameExecutor.java:74)
	at io.metadew.iesi.runtime.script.ScriptNameExecutor.execute(ScriptNameExecutor.java:26)
	at io.metadew.iesi.runtime.script.ScriptExecutorService.execute(ScriptExecutorService.java:54)
	at io.metadew.iesi.launch.ExecutionLauncher.main(ExecutionLauncher.java:58)
