### PR TITLE
Ignore case when sorting data in the UI

### DIFF
--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/component/dto/ComponentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/component/dto/ComponentDtoRepository.java
@@ -139,12 +139,12 @@ public class ComponentDtoRepository extends PaginatedRepository implements IComp
     }
 
     private String getOrderByClause(Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) return " ORDER BY component_designs.COMP_ID ";
+        if (pageable.getSort().isUnsorted()) return " ORDER BY component_designs.COMP_ID COLLATE NOCASE ASC ";
         List<String> sorting = pageable.getSort().stream().map(order -> {
                     if (order.getProperty().equalsIgnoreCase("NAME")) {
-                        return "component_designs.COMP_NM" + " " + order.getDirection();
+                        return "component_designs.COMP_NM" + " COLLATE NOCASE " + order.getDirection();
                     } else if (order.getProperty().equalsIgnoreCase("VERSION")) {
-                        return "versions.COMP_VRS_NB" + " " + order.getDirection();
+                        return "versions.COMP_VRS_NB" + " COLLATE NOCASE " + order.getDirection();
                     } else {
                         return null;
                     }
@@ -152,7 +152,7 @@ public class ComponentDtoRepository extends PaginatedRepository implements IComp
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (sorting.isEmpty()) {
-            sorting.add("ORDER BY component_designs.COMP_ID");
+            sorting.add("ORDER BY component_designs.COMP_ID COLLATE NOCASE ASC");
         }
         return " ORDER BY " + String.join(", ", sorting) + " ";
     }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepository.java
@@ -107,10 +107,10 @@ public class ConnectionDtoRepository extends PaginatedRepository implements ICon
     }
 
     private String getOrderByClause(Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) return " ORDER BY connections.CONN_NM ASC ";
+        if (pageable.getSort().isUnsorted()) return " ORDER BY connections.CONN_NM COLLATE NOCASE ASC ";
         List<String> sorting = pageable.getSort().stream().map(order -> {
                     if (order.getProperty().equalsIgnoreCase("NAME")) {
-                        return "connections.CONN_NM" + " " + order.getDirection();
+                        return "connections.CONN_NM" + " COLLATE NOCASE " + order.getDirection();
                     } else {
                         return null;
                     }
@@ -118,7 +118,7 @@ public class ConnectionDtoRepository extends PaginatedRepository implements ICon
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (sorting.isEmpty()) {
-            return " ORDER BY connections.CONN_NM ASC";
+            return " ORDER BY connections.CONN_NM COLLATE NOCASE ASC";
         }
         return " ORDER BY " + String.join(", ", sorting) + " ";
     }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/dataset/dto/DatasetDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/dataset/dto/DatasetDtoRepository.java
@@ -156,15 +156,20 @@ public class DatasetDtoRepository extends PaginatedRepository implements IDatase
     }
 
     private String getOrderByClause(Pageable pageable) {
-        if (pageable.isUnpaged()) {
-            return " ";
+        if (pageable.getSort().isUnsorted()) return " ORDER BY datasets.NAME COLLATE NOCASE ASC ";
+        List<String> sorting = pageable.getSort().stream().map(order -> {
+                    if (order.getProperty().equalsIgnoreCase("NAME")) {
+                        return "datasets.NAME " + " COLLATE NOCASE " + order.getDirection();
+                    } else {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (sorting.isEmpty()) {
+            return " ORDER BY datasets.NAME COLATTE NOCASE ASC";
         }
-        if (pageable.getSort().isUnsorted()) {
-            // set default ordering for pagination to last loaded
-            return " ORDER BY datasets.LOAD_TMS ASC ";
-        } else {
-            return " ";
-        }
+        return " ORDER BY " + String.join(", ", sorting) + " ";
     }
 
     private long getRowSize(Authentication authentication, Set<DatasetFilter> datasetFilters) throws SQLException {

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepository.java
@@ -76,10 +76,10 @@ public class EnvironmentDtoRepository extends PaginatedRepository implements IEn
     }
 
     private String getOrderByClause(Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) return " ORDER BY environments.ENV_NM ASC ";
+        if (pageable.getSort().isUnsorted()) return " ORDER BY environments.ENV_NM COLLATE NOCASE ASC ";
         List<String> sorting = pageable.getSort().stream().map(order -> {
             if (order.getProperty().equalsIgnoreCase("NAME")) {
-                return "environments.ENV_NM" + " " + order.getDirection();
+                return "environments.ENV_NM" + " COLLATE NOCASE " + order.getDirection();
             } else {
                 return null;
             }
@@ -87,7 +87,7 @@ public class EnvironmentDtoRepository extends PaginatedRepository implements IEn
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (sorting.isEmpty()) {
-            return " ORDER BY environments.ENV_NM ASC";
+            return " ORDER BY environments.ENV_NM COLLATE NOCASE ASC";
         }
         return " ORDER BY " + String.join(", ", sorting) + " ";
     }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/script/dto/ScriptDtoRepository.java
@@ -135,9 +135,9 @@ public class ScriptDtoRepository extends PaginatedRepository implements IScriptD
         List<String> sorting = pageable.getSort().stream().map(order -> {
             // add further sort on the ScriptAndScriptVersionTable here
             if (order.getProperty().equalsIgnoreCase("NAME")) {
-                return "script_designs.SCRIPT_NM" + " " + order.getDirection();
+                return "script_designs.SCRIPT_NM" + " COLLATE NOCASE " + order.getDirection();
             } else if (order.getProperty().equalsIgnoreCase("VERSION")) {
-                return "versions.SCRIPT_VRS_NB" + " " + order.getDirection();
+                return "versions.SCRIPT_VRS_NB" + " COLLATE NOCASE " + order.getDirection();
             } else {
                 return null;
             }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/security_group/SecurityGroupDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/security_group/SecurityGroupDtoRepository.java
@@ -91,7 +91,7 @@ public class SecurityGroupDtoRepository extends PaginatedRepository implements I
         if (pageable.getSort().isUnsorted()) return " ORDER BY security_groups.id";
         List<String> sorting = pageable.getSort().stream().map(order -> {
                     if (order.getProperty().equalsIgnoreCase("NAME")) {
-                        return "security_groups.name " + order.getDirection();
+                        return "security_groups.name " + " COLLATE NOCASE " + order.getDirection();
                     } else {
                         return null;
                     }

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/UserDtoListResultSetExtractor.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/UserDtoListResultSetExtractor.java
@@ -48,7 +48,7 @@ public class UserDtoListResultSetExtractor {
         }
     }
 
-    private void addRole(UserDtoBuilder userDtoBuilder, CachedRowSet cachedRowSet) throws SQLException {
+    private void addRole(UserDtoBuilder userDtoBuilder, CachedRowSet cachedRowSet) throws SQLException {;
         if (cachedRowSet.getString("role_id") != null) {
             UserRoleDtoBuilder userRoleDtoBuilder = userDtoBuilder.getRoles().computeIfAbsent(
                     UUID.fromString(cachedRowSet.getString("role_id")),

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/UserDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/UserDtoRepository.java
@@ -110,10 +110,10 @@ public class UserDtoRepository extends PaginatedRepository implements IUserDtoRe
     }
 
     private String getOrderByClause(Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) return " ORDER BY users.username ASC ";
+        if (pageable.getSort().isUnsorted()) return " ORDER BY users.username COLLATE NOCASE ASC ";
         List<String> sorting = pageable.getSort().stream().map(order -> {
                     if (order.getProperty().equalsIgnoreCase("USERNAME")) {
-                        return "users.username" + " " + order.getDirection();
+                        return "users.username" + " COLLATE NOCASE " + order.getDirection();
                     } else {
                         return null;
                     }
@@ -121,7 +121,7 @@ public class UserDtoRepository extends PaginatedRepository implements IUserDtoRe
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (sorting.isEmpty()) {
-            sorting.add("ORDER BY users.username");
+            sorting.add("users.username COLLATE NOCASE");
         }
 
         return " ORDER BY " + String.join(", ", sorting) + " ";

--- a/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/team/TeamDtoRepository.java
+++ b/core/java/iesi-rest-without-microservices/src/main/java/io/metadew/iesi/server/rest/user/team/TeamDtoRepository.java
@@ -127,7 +127,7 @@ public class TeamDtoRepository extends PaginatedRepository implements ITeamDtoRe
         if (pageable.getSort().isUnsorted()) return " ORDER BY teams.id";
         List<String> sorting = pageable.getSort().stream().map(order -> {
                     if (order.getProperty().equalsIgnoreCase("NAME")) {
-                        return "teams.team_name " + order.getDirection();
+                        return "teams.team_name " + " COLLATE NOCASE " + order.getDirection();
                     } else {
                         return null;
                     }

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/component/dto/ComponentRepositoryDtoTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/component/dto/ComponentRepositoryDtoTest.java
@@ -191,6 +191,22 @@ class ComponentRepositoryDtoTest {
     }
 
     @Test
+    void getAllSortedCaseTest() {
+        Component component1 = createComponent("a", "1", "PUBLIC");
+        Component component2 = createComponent("Z", "2", "PUBLIC");
+        componentConfiguration.insert(component1);
+        componentConfiguration.insert(component2);
+        ComponentDto component1Dto = componentDtoResourceAssembler.toModel(component1);
+        ComponentDto component2Dto = componentDtoResourceAssembler.toModel(component2);
+
+        PageRequest pageableASC = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "name"));
+        PageRequest pageabledESC = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name"));
+
+        assertThat(componentDtoRepository.getAll(null, pageableASC, new ArrayList<>())).containsExactly(component1Dto, component2Dto);
+        assertThat(componentDtoRepository.getAll(null, pageabledESC, new ArrayList<>())).containsExactly(component2Dto, component1Dto);
+    }
+
+    @Test
     void getAllFilteredOnNameTest() {
         Component component1 = createComponent("component1", "1", "PUBLIC");
         Component component2 = createComponent("component2", "2", "PUBLIC");

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/connection/dto/ConnectionDtoRepositoryTest.java
@@ -196,6 +196,26 @@ class ConnectionDtoRepositoryTest {
     }
 
     @Test
+    void getAllUpperCaseSortTest() {
+        List<Connection> connection1 = createConnection("a", Stream.of("env1", "env2").collect(Collectors.toList()), "PUBLIC");
+        List<Connection> connection2 = createConnection("Z", Stream.of("env1", "env2").collect(Collectors.toList()), "PUBLIC");
+
+        environmentConfiguration.insert(createEnvironment("env1"));
+        environmentConfiguration.insert(createEnvironment("env2"));
+        insert(connection1);
+        insert(connection2);
+        ConnectionDto connection1Dto = createConnectionDto(connection1);
+        ConnectionDto connection2Dto = createConnectionDto(connection2);
+
+        PageRequest pageableASC = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "name"));
+        PageRequest pageableDESC = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name"));
+
+
+        assertThat(connectionDtoRepository.getAll(null, pageableASC, new ArrayList<>())).containsExactly(connection1Dto, connection2Dto);
+        assertThat(connectionDtoRepository.getAll(null, pageableDESC, new ArrayList<>())).containsExactly(connection2Dto, connection1Dto);
+    }
+
+    @Test
     void getAllFilteredOnNameTest() {
         List<Connection> connection1 = createConnection("connection1", Stream.of("env1", "env2").collect(Collectors.toList()), "PUBLIC");
         List<Connection> connection2 = createConnection("connection2", Stream.of("env1", "env2").collect(Collectors.toList()), "PUBLIC");

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/dataset/DatasetDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/dataset/DatasetDtoRepositoryTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -64,6 +65,45 @@ class DatasetDtoRepositoryTest {
     @AfterEach
     void cleanup() {
         metadataRepositoryConfiguration.clearAllTables();
+    }
+
+    @Test
+    void getAllSortedCaseTest() {
+        Dataset dataset1 = Dataset.builder()
+                .metadataKey(new DatasetKey(UUID.randomUUID()))
+                .securityGroupKey(new SecurityGroupKey(UUID.randomUUID()))
+                .securityGroupName("PUBLIC")
+                .name("a")
+                .datasetImplementations(new HashSet<>())
+                .build();
+        DatasetDto dataset1Dto = DatasetDto.builder()
+                .uuid(dataset1.getMetadataKey().getUuid())
+                .name("a")
+                .securityGroupName("PUBLIC")
+                .implementations(new HashSet<>())
+                .build();
+        Dataset dataset2 = Dataset.builder()
+                .metadataKey(new DatasetKey(UUID.randomUUID()))
+                .securityGroupKey(new SecurityGroupKey(UUID.randomUUID()))
+                .securityGroupName("PUBLIC")
+                .name("Z")
+                .datasetImplementations(new HashSet<>())
+                .build();
+        DatasetDto dataset2Dto = DatasetDto.builder()
+                .uuid(dataset2.getMetadataKey().getUuid())
+                .name("Z")
+                .securityGroupName("PUBLIC")
+                .implementations(new HashSet<>())
+                .build();
+
+        datasetConfiguration.insert(dataset1);
+        datasetConfiguration.insert(dataset2);
+
+        Pageable pageableASC = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "name"));
+        Pageable pageableDESC = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name"));
+
+        assertThat(datasetDtoRepository.fetchAll(null, pageableASC, new HashSet<>())).containsExactly(dataset1Dto, dataset2Dto);
+        assertThat(datasetDtoRepository.fetchAll(null, pageableDESC, new HashSet<>())).containsExactly(dataset2Dto, dataset1Dto);
     }
 
     @Test

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/environment/dto/EnvironmentDtoRepositoryTest.java
@@ -70,6 +70,20 @@ class EnvironmentDtoRepositoryTest {
     }
 
     @Test
+    void getAllSortedCaseTest() {
+        Environment environment1 = createEnvironment("a");
+        Environment environment2 = createEnvironment("Z");
+        environmentConfiguration.insert(environment1);
+        environmentConfiguration.insert(environment2);
+        EnvironmentDto environmentDto1 = environmentDtoResourceAssembler.toModel(environment1);
+        EnvironmentDto environmentDto2 = environmentDtoResourceAssembler.toModel(environment2);
+        Pageable pageableASC = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "name"));
+        Pageable pageableDESC = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name"));
+
+        assertThat(environmentDtoRepository.getAll(pageableASC)).containsExactly(environmentDto1, environmentDto2);
+        assertThat(environmentDtoRepository.getAll(pageableDESC)).containsExactly(environmentDto2, environmentDto1);
+    }
+    @Test
     void getAllPaginatedAllInclusiveTest() {
         Environment environment1 = createEnvironment("iesi-dev");
         Environment environment2 = createEnvironment("iesi-sit");

--- a/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/user/UserDtoRepositoryTest.java
+++ b/core/java/iesi-rest-without-microservices/src/test/java/io/metadew/iesi/server/rest/user/UserDtoRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -80,6 +81,26 @@ class UserDtoRepositoryTest {
                 userDtoRepository.getAll(pageable, new UserFiltersBuilder().username("filter").build()))
                 .hasSize(1)
                 .contains((UserDto) user1Info.get("userDto"));
+    }
+
+    @Test
+    void getAllSortedCaseTest() {
+        Map<String, Object> teamInfo = TeamBuilder.generateTeam(1, 1, 2, new HashSet<>());
+        Team team = (Team) teamInfo.get("team");
+        teamConfiguration.insert((Team) teamInfo.get("team"));
+        Map<String, Object> user1Info = UserBuilder.generateUser("a", team.getRoles(), team.getTeamName(), new HashSet<>());
+        Map<String, Object> user2Info = UserBuilder.generateUser("Z", team.getRoles(), team.getTeamName(), new HashSet<>());
+        userConfiguration.insert((User) user1Info.get("user"));
+        userConfiguration.insert((User) user2Info.get("user"));
+
+        UserDto user1Dto = (UserDto) user1Info.get("userDto");
+        UserDto user2Dto = (UserDto) user2Info.get("userDto");
+
+        Pageable pageableASC = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "username"));
+        Pageable pageableDESC = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "username"));
+
+        assertThat(userDtoRepository.getAll(pageableASC, new HashSet<>())).containsExactly(user1Dto, user2Dto);
+        assertThat(userDtoRepository.getAll(pageableDESC, new HashSet<>())).containsExactly(user2Dto, user1Dto);
     }
 
 }


### PR DESCRIPTION
**ID**
a0cd7c9

Able to sort data in the UI by name by ignoring the case sensitivity. Even a name begins with an higher letter than another but in uppercase, it will be after the lower letter, and not before.