### PR TITLE
Allow text pattern testing

### DIFF
--- a/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextRegex.java
+++ b/core/java/iesi-core/src/main/java/io/metadew/iesi/script/execution/instruction/data/text/TextRegex.java
@@ -1,0 +1,55 @@
+package io.metadew.iesi.script.execution.instruction.data.text;
+
+import io.metadew.iesi.SpringContext;
+import io.metadew.iesi.datatypes.DataType;
+import io.metadew.iesi.datatypes.DataTypeHandler;
+import io.metadew.iesi.datatypes.text.Text;
+import io.metadew.iesi.script.execution.ExecutionRuntime;
+import io.metadew.iesi.script.execution.instruction.data.DataInstruction;
+import org.apache.xerces.impl.xpath.regex.Match;
+
+import java.text.MessageFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TextRegex implements DataInstruction {
+
+    private final ExecutionRuntime executionRuntime;
+
+    private final String TEXT = "text";
+    private final String PATTERN = "pattern";
+
+    private final Pattern pattern = Pattern.compile("(?<" + TEXT +">.+),(?<" + PATTERN + ">.+)");
+
+    public TextRegex(ExecutionRuntime executionRuntime) {
+        this.executionRuntime = executionRuntime;
+    }
+
+
+    @Override
+    public String getKeyword() {
+        return "text.regex";
+    }
+
+    @Override
+    public String generateOutput(String parameters) {
+        DataType resolvedParameters = SpringContext.getBean(DataTypeHandler.class).resolve(parameters, executionRuntime);
+        if (!(resolvedParameters instanceof Text)) {
+            throw new IllegalArgumentException(String.format("text cannot be a type of %s", resolvedParameters.getClass()));
+        }
+
+        Matcher matcher = pattern.matcher(((Text) resolvedParameters).getString());
+
+        if (matcher.find()) {
+            Pattern providedPattern = Pattern.compile(matcher.group(PATTERN));
+
+            Matcher providedMatcher = providedPattern.matcher(matcher.group(TEXT));
+
+            if (providedMatcher.find()) {
+                return providedMatcher.group();
+            }
+        }
+
+        return "";
+    }
+}

--- a/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextRegexTest.java
+++ b/core/java/iesi-core/src/test/java/io/metadew/iesi/script/execution/instruction/data/text/TextRegexTest.java
@@ -1,0 +1,87 @@
+package io.metadew.iesi.script.execution.instruction.data.text;
+
+import io.metadew.iesi.TestConfiguration;
+import io.metadew.iesi.datatypes.DataTypeHandler;
+import io.metadew.iesi.datatypes.text.Text;
+import io.metadew.iesi.script.execution.ExecutionRuntime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { TestConfiguration.class, DataTypeHandler.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+public class TextRegexTest {
+
+    TextRegex textRegex;
+
+    @MockBean
+    DataTypeHandler dataTypeHandler;
+
+    @BeforeEach
+    void beforeEach() {
+        ExecutionRuntime executionRuntime = mock(ExecutionRuntime.class);
+        textRegex = new TextRegex(executionRuntime);
+    }
+
+    @Test
+    void generateOutput() {
+        String text = "Hello world";
+        String pattern = "world";
+
+        when(dataTypeHandler.resolve(eq(String.format("%s,%s", text, pattern)), isA(ExecutionRuntime.class)))
+                .thenReturn(new Text(String.format("%s,%s", text, pattern)));
+
+        assertThat(textRegex.generateOutput(String.format("%s,%s", text, pattern)))
+                .isEqualTo("world");
+    }
+
+    @Test
+    void generateOutputNotFound() {
+        String text = "Hello worl";
+        String pattern = "world";
+
+        when(dataTypeHandler.resolve(eq(String.format("%s,%s", text, pattern)), isA(ExecutionRuntime.class)))
+                .thenReturn(new Text(String.format("%s,%s", text, pattern)));
+
+        assertThat(textRegex.generateOutput(String.format("%s,%s", text, pattern)))
+                .isEqualTo("");
+    }
+
+
+    @Test
+    void generateOutputComplexPattern() {
+        String text = "Hello my e-mail address is test.unit@accenture.com";
+        String pattern = "[^@\\s]*@.+\\.[a-z]*";
+
+        when(dataTypeHandler.resolve(eq(String.format("%s,%s", text, pattern)), isA(ExecutionRuntime.class)))
+                .thenReturn(new Text(String.format("%s,%s", text, pattern)));
+
+        assertThat(textRegex.generateOutput(String.format("%s,%s", text, pattern)))
+                .isEqualTo("test.unit@accenture.com");
+    }
+
+    @Test
+    void generateOutputComplexPatternNotFound() {
+        String text = "Hello my e-mail address is test.unitaccenture.com";
+        String pattern = "[^@\\s]*@.+\\.[a-z]*";
+
+        when(dataTypeHandler.resolve(eq(String.format("%s,%s", text, pattern)), isA(ExecutionRuntime.class)))
+                .thenReturn(new Text(String.format("%s,%s", text, pattern)));
+
+        assertThat(textRegex.generateOutput(String.format("%s,%s", text, pattern)))
+                .isEqualTo("");
+    }
+}


### PR DESCRIPTION
**ID**
65f71b8

**Description**
Users have to be able to find for a specific words/set of words by using Regex patterns.
More information about Regex: en.wikipedia.org/wiki/Regular_expression

**AS IF**
Users use text.substring to slice a text and get a particular set of words --> Not accurate since the text could be changed and lead to a change on the script design since the set of words could not be on the same index position in the text.
**TO BE**
Users use text.regex(text, pattern) and target a a set of words that match the pattern. If the text change, it doesn't matter since the target is not based on variable components.